### PR TITLE
Refactor Clean target to avoid triggering mono 3.2 bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ debug:
 clean:
 	cd build && xbuild FLExBridge.build.mono.proj /t:Clean /p:RootDir=..
 	/bin/rm -rf output Download Mercurial
-	/usr/bin/find . -name obj -type d -print | xargs /bin/rm -rf
 
 install: release
 	cd build && xbuild FLExBridge.build.mono.proj /t:Prepackaging /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=notthere /p:BUILD_NUMBER=$(BUILD_NUMBER) /p:Configuration=ReleaseMono

--- a/build/FLExBridge.build.mono.proj
+++ b/build/FLExBridge.build.mono.proj
@@ -27,14 +27,15 @@
   </Target>
 
   <ItemGroup>
-	<ExistingObjectFiles Include="$(RootDir)/**/obj/**/*;$(RootDir)/output/**/*" Exclude="$(RootDir)/.hg/**/*"/>
-	<OutputDirectory Include="$(RootDir)\output\"/>
+	<OutputFiles
+		Include="$(RootDir)/output/$(Configuration)/**/*"
+		Exclude="$(RootDir)/.hg/**/*;$(RootDir)/.git/**/*"
+	/>
   </ItemGroup>
-
   <Target Name="Clean">
 	<Message Text="Starting Clean"/>
-	<Delete Files="@(ExistingObjectFiles)"/>
-	<RemoveDir Directories="$(OutputDirectory)"/>
+	<Exec Command="find . -name obj -type d -print0 | xargs -0 rm -rf" WorkingDirectory="$(RootDir)" />
+	<Delete Files="@(OutputFiles)" />
 	<Message Text="End Clean"/>
   </Target>
 


### PR DESCRIPTION
- This bug completely wipes out the working directory, instead of just
  removing the object files
- The solution is adapted from WeSay
- mono 3.2 is the system mono on trusty
