### PR TITLE
Add geckofx runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Package: flexbridge
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7), python (<< 2.8),
  fieldworks-mono, libgtk2.0-dev, libgtkmm-2.4-1c2a, libgtkmm-2.4-dev,
- libgtksourceview2.0-0, libgtksourceview2.0-common
+ libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx
 Suggests: fieldworks-applications (>= 8.0.5~beta6)
 Description: Allow multiple FieldWorks users to collaborate remotely
  FLEx Bridge is an application that allows multiple FieldWorks 8.0 users


### PR DESCRIPTION
Add geckofx runtime dependency

This corrects the dependencies and allow flexbridge to be installed independenty for chorushub.
