### PR TITLE
Update flexbridge Beta to work with tagged ICU build

### DIFF
--- a/build/Download.targets
+++ b/build/Download.targets
@@ -162,16 +162,16 @@
 	<Target Name="DownloadDotNetAssemblies" Condition="'$(OS)'=='Windows_NT' And '$(TeamCityBuild)'!='true'">
 		<MakeDir Directories="$(RootDir)/Download"/>
 		<!-- bt14 is the icucil-win32-default Continuous build. -->
-		<Message Text="Downloading latest successful artifacts from the icucil-win32-default Continuous build."/>
-		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/.lastSuccessful/icu.net.dll"
+		<Message Text="Downloading latest successful artifacts tagged icu40 from the icucil-win32-default Continuous build."/>
+		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/icu40.tcbuildtag/icu.net.dll"
 					  LocalFilename="$(RootDir)/Download/icu.net.dll"/>
-		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/.lastSuccessful/icu.net.dll.config"
+		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/icu40.tcbuildtag/icu.net.dll.config"
 					  LocalFilename="$(RootDir)/Download/icu.net.dll.config"/>
-		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/.lastSuccessful/icudt40.dll"
+		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/icu40.tcbuildtag/icudt40.dll"
 					  LocalFilename="$(RootDir)/Download/icudt40.dll"/>
-		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/.lastSuccessful/icuin40.dll"
+		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/icu40.tcbuildtag/icuin40.dll"
 					  LocalFilename="$(RootDir)/Download/icuin40.dll"/>
-		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/.lastSuccessful/icuuc40.dll"
+		<DownloadFile Address="http://build.palaso.org/guestAuth/repository/download/bt14/icu40.tcbuildtag/icuuc40.dll"
 					  LocalFilename="$(RootDir)/Download/icuuc40.dll"/>
 
 		<!-- bt273 is the palaso-win32-FlexBridgeBeta Continuous build. -->

--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,8 @@ Package: flexbridge
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7), python (<< 2.8),
  fieldworks-mono, libgtk2.0-dev, libgtkmm-2.4-1c2a, libgtkmm-2.4-dev,
- libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx
-Suggests: fieldworks-applications (>= 8.0.5~beta6)
+ libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx,
+ fieldworks-applications (>= 8.0.5~beta6), fieldworks-applications (<< 8.2)
 Description: Allow multiple FieldWorks users to collaborate remotely
  FLEx Bridge is an application that allows multiple FieldWorks 8.0 users
  to do remote collaboration (i.e., not necessarily connected by a local


### PR DESCRIPTION
* Use the pinned and tagged icu40 build from TC
* Change suggests to require for fieldworks and restrict
  the maximum version.