### PR TITLE
Add unzip to binary dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Package: flexbridge
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7), python (<< 2.8),
  mono-sil, libgdiplus-sil, libgtk2.0-dev, libgtkmm-2.4-1c2a, libgtkmm-2.4-dev,
- libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx29,
+ libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx29, unzip,
  fieldworks-applications (>> 8.1.9)
 Description: Allow multiple FieldWorks users to collaborate remotely
  FLEx Bridge is an application that allows multiple FieldWorks 8.0 users


### PR DESCRIPTION
posinst requires unzip to unpack mercurial.