### PR TITLE
Revert the Schedule attribute change and add dev target

### DIFF
--- a/build/FLExBridge.build.win.proj
+++ b/build/FLExBridge.build.win.proj
@@ -69,8 +69,13 @@
 
   <!-- *********************** Installer stuff below.  ******************************* -->
 
-  <Target Name="Installer" DependsOnTargets="VersionNumbers; CreateDirectories; Test">
+  <!-- For building an an installer on TC -->
+  <Target Name="Installer" DependsOnTargets="DevelopInstaller; Test"/>
 
+  <!-- For use when working on installer development -->
+  <!-- To build the installer from the build folder to build on a developer machine use something similar to the following: -->
+  <!-- msbuild FLExBridge.build.win.proj /t:DevelopInstaller /p:BuildCounter=99 /p:BUILD_VCS_NUMBER=24445 /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=none /p:UploadFolder=Alpha/p:Configuration=Release /p:Platform="Any CPU" -->
+  <Target Name="DevelopInstaller" DependsOnTargets="VersionNumbers; CreateDirectories; Build">
 	<Copy SourceFiles="$(RootDir)\src\Installer\Installer.wxs" DestinationFolder="$(RootDir)\output\Installer"/>
 	<FileUpdate File="$(RootDir)\src\Installer\Installer.wxs" Regex="Property_ProductVersion = &quot;.*&quot;" ReplacementText="Property_ProductVersion = &quot;$(Version)&quot;"/>
 
@@ -79,7 +84,6 @@
 
 	<!-- Copy Installer.wxs back so it appears we aren't modifying the original, which then is a pain on dev machines -->
 	<Copy SourceFiles="$(RootDir)\output\Installer\Installer.wxs" DestinationFolder="$(RootDir)\src\Installer"/>
-
   </Target>
 
   <Target Name="Upload" DependsOnTargets="CreateDirectories">

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -26,7 +26,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 	<WixVariable Id="WixUIDialogBmp" Value="DialogBGWithSILLogo.bmp" />
 
 	<!-- Using afterInstallFinalize will allow the apparent downgrading of files in the Chorus merge module. -->
-	<MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallFinalize"/>
+	<MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
 
 	<Property Id="MANUFACTURERREGKEY">SIL</Property>
 	<!-- The following will set properties A[FW8INSTALLDIR] and B[FW8DEVINSTALLDIR] to the result of two different registry searches.


### PR DESCRIPTION
The Chorus merge module will not function correctly if the Schedule
attribute is anything but afterInstallValidate

* Reset 'Schedule' to afterInstallValidate
* Add DevelopInstaller target and comment for how to validate installer
  work on a developer machine