### PR TITLE
Add the fixutf8 plugin to Mercurial.ini in postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,6 +25,7 @@ case "$1" in
 			ARCH="$(/usr/bin/arch)"
 			unzip Mercurial-${ARCH}.zip
 			chmod +x Mercurial/hg
+			echo "fixutf8=/usr/lib/flexbridge/MercurialExtensions/fixutf8/fixutf8.py" >> Mercurial/mercurial.ini
 		fi
 
 		UID_MIN=$(sed -n '/^UID_MIN[ \t][ \t]*/s///p' /etc/login.defs)


### PR DESCRIPTION
The plugin is required on linux after the upgrade to mercurial 3
in order to handle integer only branch names.