### PR TITLE
Install ChorusHub on linux until a separate package is created

### DIFF
--- a/build/FLExBridge.build.mono.proj
+++ b/build/FLExBridge.build.mono.proj
@@ -78,6 +78,7 @@
 	<LocalizeFiles Include="$(RootDir)/DistFiles/localizations/*"/>
 	<!-- NDeskDbus is required only so that Palaso can be localized on linux -->
 	<NDeskDBusFiles Include="$(RootDir)/lib/$(Configuration)/NDesk.DBus.dll*"/>
+	<ChorusHubFiles Include="$(RootDir)/lib/$(Configuration)/ChorusHub.*"/>
   </ItemGroup>
 
   <Target Name="CopyExtraFilesToOutput">
@@ -86,6 +87,7 @@
 	<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 	<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/localizations"/>
 	<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
+	<Copy SourceFiles="@(ChorusHubFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
   </Target>
 
   <Target Name="Compile" DependsOnTargets="CopyExtraFilesToOutput; RestorePackages">


### PR DESCRIPTION
* The shortcut had not yet been removed and we don't have a package
  for ChorusHub yet. So until we can make one include ChorusHub.exe
  so that the shortcut will launch the service.