### PR TITLE
Update release documentation, increase version to 2.3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CPUARCH=$(shell /usr/bin/arch)
 # this needs to be in sync with debian/changelog and build/build.common.proj
-BUILD_NUMBER="2.3.8"
+BUILD_NUMBER="2.3.9"
 BUILD_VCS_NUMBER="e1064efa2c6a13e2cf1752f4a61e30e42e21ce55"
 UploadFolder="Alpha"
 # Work around proxy bug in older mono to allow dependency downloads

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,3 +44,9 @@ Also, if you are working on Chorus:
    UpdateFLExDependencies.bat script in the flexbridge repo
 These steps are required for only those dependencies bound at compile time (e.g. API changes):
 - Rebuild FLEx
+## Release Notes:
+When releasing FLExBridge be sure to do the following:
+### Update the ReleaseNotes.md and [ReleaseType].htm for the ReleaseType e.g. Alpha, Beta, Stable with the user facing change information.
+### If you are making a major or minor version number jump update the the first two digits in build/build.common.proj
+### The windows version is released through two jobs in TeamCity, "Installer-sans Publish" and "Publish Installer", the final version number comes from the TC job on "Installer-sans Publish". If you need to make a fix before publishing you can avoid incrementing the version number by setting the buid counter back on the Installer-sans Publish job and re-running it before running the publish job.
+### For the Linux release update the Makefile and add a debian/changelog entry and then use the Jenkins FLExBridge release package build to make packages from the commit where the changelog entry was updated.

--- a/build/FLExBridge.build.win.proj
+++ b/build/FLExBridge.build.win.proj
@@ -95,7 +95,7 @@
 	<Exec Command="&quot;c:\program files\cwRsync\bin\rsync.exe&quot; -vz -p --chmod=ug+rw,o+r -e&quot;\&quot;c:\program files\cwRsync\bin\ssh\&quot; -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob&quot;  &quot;../output/Installer/ReleaseNotes.md&quot; bob@palaso.org:/var/www/virtual/palaso.org/downloads/htdocs/FlexBridge/$(UploadFolder)/ReleaseNotes.md"/>
 
 	<Message Text="Attempting rsync of appcast.xml" Importance="high"/>
-	<Exec Command="&quot;c:\program files\cwRsync\bin\rsync.exe&quot; -vz -p --chmod=ug+rw,o+r -e&quot;\&quot;c:\program files\cwRsync\bin\ssh\&quot; -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob&quot;  &quot;../output/Installer/appcast.xml&quot; bob@palaso.org:/var/www/virtual/palaso.org/downloads/htdocs/FlexBridge/appcast.xml"/>
+	<Exec Command="&quot;c:\program files\cwRsync\bin\rsync.exe&quot; -vz -p --chmod=ug+rw,o+r -e&quot;\&quot;c:\program files\cwRsync\bin\ssh\&quot; -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob&quot;  &quot;../output/Installer/appcast.xml&quot; bob@palaso.org:/var/www/virtual/palaso.org/downloads/htdocs/FlexBridge/$(UploadFolder)/appcast.xml"/>
 
 	<Message Text="Attempting rsync of flexbridge.css" Importance="high"/>
 	<Exec Command="&quot;c:\program files\cwRsync\bin\rsync.exe&quot; -vz -p --chmod=ug+rw,o+r -e&quot;\&quot;c:\program files\cwRsync\bin\ssh\&quot; -oUserKnownHostsFile=C:\BuildAgent\conf\known_hosts -oIdentityFile=C:\BuildAgent\conf\bob.key -l bob&quot;  &quot;../src/Installer/flexbridge.css&quot; bob@palaso.org:/var/www/virtual/palaso.org/downloads/htdocs/FlexBridge/flexbridge.css"/>

--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-	<BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">2.3.5</BUILD_NUMBER>
+	<BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">2.3.9</BUILD_NUMBER>
   </PropertyGroup>
 
   <Import Project="$(RootDir)\build\NuGet.targets"/>

--- a/src/Installer/Alpha.htm
+++ b/src/Installer/Alpha.htm
@@ -8,6 +8,16 @@
 		<h4>Release Notes (Preview of things to come)</h4>
 		<ul>
 			<li>DEV_VERSION_NUMBER<ol>
+				<li>Chorus: Update documentation of Chorus Hub</li>
+				<li>FLExBridge: Update documentation of recent fixes</li>
+			</ol></li>
+			<li>2.3.8<ol>
+				<li>Chorus: Make large internet Send/Receive options more robust (Warning instead of error when retrying a failed Chunk)</li>
+				<li>Chorus: Improve Chorus Hub Instructions</li>
+				<li>FLExBridge: Provide Chorus Hub Service option on Linux</li>
+				<li>FLExBridge: Various linux installer enhancements</li>
+			</ol></li>
+			<li>2.3.5<ol>
 				<li>L10NSharp: Improve debug information for linux localization</li>
 			</ol></li>
 			<li>2.3.2<ol>

--- a/src/Installer/ReleaseNotes.md
+++ b/src/Installer/ReleaseNotes.md
@@ -1,4 +1,12 @@
 ## DEV_VERSION_NUMBER: DEV_RELEASE_DATE
+* Chorus: Update documentation of Chorus Hub
+* FLExBridge: Update documentation of recent fixes
+## 2.3.8 24/Sep/2015
+* Chorus: Make large internet Send/Receive options more robust (Warning instead of error when retrying a failed Chunk)
+* Chorus: Improve Chorus Hub Instructions
+* FLExBridge: Provide Chorus Hub Service option on Linux
+* FLExBridge: Various linux installer enhancements
+## 2.3.5 3/Sep/2015
 * L10NSharp: Improve debug information for linux localization
 ## 2.3.2
 * FLEx Bridge: Enhance Windows installer

--- a/src/Installer/appcast.xml
+++ b/src/Installer/appcast.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
-	  <title>FLEx Bridge Releases</title>
+	  <title>FLEx Bridge Preview Releases</title>
 	  <link>http://downloads.palaso.org/FlexBridge/index.htm</link>
 	  <description>Most recent changes with links to updates.</description>
 	  <language>en</language>
 		 <item>
 			<title>Version DEV_VERSION_NUMBER</title>
 						<sparkle:releaseNotesLink>
-							http://downloads.palaso.org/FlexBridge/Beta/ReleaseNotes.md
+							http://downloads.palaso.org/FlexBridge/Alpha/ReleaseNotes.md
 						</sparkle:releaseNotesLink>
-			<enclosure url="http://downloads.palaso.org/FlexBridge/Beta/FLExBridgeInstaller.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
+			<enclosure url="http://downloads.palaso.org/FlexBridge/Alpha/FLExBridgeInstaller.msi" sparkle:version="DEV_VERSION_NUMBER" type="application/octet-stream" />
 		 </item>
    </channel>
 </rss>

--- a/src/Installer/index.htm
+++ b/src/Installer/index.htm
@@ -26,6 +26,11 @@ When FLEx Bridge is used with the xml file system, both types of data sharing ar
 			<tbody>
 				<tr>
 					<td id="beta" >
+						<iframe id="Beta" src="Beta/Beta.htm" title="FLEx Bridge">
+							<p>Your browser does not support iframes.</p>
+						</iframe>
+					</td>
+					<td id="alpha" >
 						<iframe id="Alpha" src="Alpha/Alpha.htm" title="FLEx Bridge">
 							<p>Your browser does not support iframes.</p>
 						</iframe>

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/CheckForUpdatesActionTypeHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/CheckForUpdatesActionTypeHandler.cs
@@ -28,7 +28,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 		public void StartWorking(Dictionary<string, string> commandLineArgs)
 		{
 #if !MONO
-			using (var sparkle = new Sparkle(@"http://downloads.palaso.org/FlexBridge/appcast.xml", CommonResources.chorus32x32))
+			using (var sparkle = new Sparkle(@"http://downloads.palaso.org/FlexBridge/Alpha/appcast.xml", CommonResources.chorus32x32))
 			{
 				sparkle.DoLaunchAfterUpdate = false;
 				sparkle.CheckForUpdatesAtUserRequest();


### PR DESCRIPTION
* Update Alpha.htm and ReleaseNotes.md with some historical information
* Update the ReadMe.md with release instructions
* Update the Makefile to generate the right version number
* Update the build.common.proj even though it isn't necessary
* Update the appcast.xml so that the next Alpha release should be
  offered to users automatically.
* Update the index.html to offer information about both Beta and Alpha
  releases