### PR TITLE
LT-16969 second sync crash

### DIFF
--- a/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
@@ -130,6 +130,8 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 				return;
 			var xsdPathInProject = Path.Combine(Path.GetDirectoryName(commandLineArgs["-p"]), "Temp", SharedConstants.DictConfigSchemaFilename);
 			File.Copy(xsdPath, xsdPathInProject, true);
+			// LT-16969 Make sure the file is not read-only, so we can copy over it next time (or when there's an update)
+			File.SetAttributes(xsdPathInProject, FileAttributes.Normal);
 		}
 
 		/// <summary>Removes .hg repo and other files and folders created by S/R Project</summary>

--- a/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
@@ -128,7 +128,10 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 				xsdPath = Path.Combine(fwAppsDir, "..", "..", "DistFiles", innerXsdPath);
 			if (!File.Exists(xsdPath))
 				return;
-			var xsdPathInProject = Path.Combine(Path.GetDirectoryName(commandLineArgs["-p"]), "Temp", SharedConstants.DictConfigSchemaFilename);
+			var xsdDirInProject = Path.Combine(Path.GetDirectoryName(commandLineArgs["-p"]), "Temp");
+			if (!Directory.Exists(xsdDirInProject))
+				Directory.CreateDirectory(xsdDirInProject);
+			var xsdPathInProject = Path.Combine(xsdDirInProject, SharedConstants.DictConfigSchemaFilename);
 			File.Copy(xsdPath, xsdPathInProject, true);
 			// LT-16969 Make sure the file is not read-only, so we can copy over it next time (or when there's an update)
 			File.SetAttributes(xsdPathInProject, FileAttributes.Normal);


### PR DESCRIPTION
* Make sure Temp folder exists
* After copying xsd file, make sure it's not read-only
  (which would interfere with copying it again later)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/78)
<!-- Reviewable:end -->
