### PR TITLE
Update Linux packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 	. ./environ && cd build && xbuild FLExBridge.build.mono.proj /t:Clean /p:RootDir=..
 	/bin/rm -rf output Download Mercurial
 
-install: release
+install:
 	/usr/bin/install -d $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install output/ReleaseMono/*.* $(DESTDIR)/usr/lib/flexbridge
 	/bin/chmod -x $(DESTDIR)/usr/lib/flexbridge/*.htm

--- a/build/FLExBridge.build.mono.proj
+++ b/build/FLExBridge.build.mono.proj
@@ -79,6 +79,7 @@
 	<!-- NDeskDbus is required only so that Palaso can be localized on linux -->
 	<NDeskDBusFiles Include="$(RootDir)/lib/$(Configuration)/NDesk.DBus.dll*"/>
 	<ChorusHubFiles Include="$(RootDir)/lib/$(Configuration)/ChorusHub.*"/>
+	<ConfigFiles Include="$(RootDir)/lib/$(Configuration)/*.dll.config"/>
   </ItemGroup>
 
   <Target Name="CopyExtraFilesToOutput">
@@ -88,6 +89,7 @@
 	<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/localizations"/>
 	<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 	<Copy SourceFiles="@(ChorusHubFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
+	<Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
   </Target>
 
   <Target Name="Compile" DependsOnTargets="CopyExtraFilesToOutput; RestorePackages">

--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -49,7 +49,7 @@
 	<Target Name="_DownloadNuGet" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')">
 		<DownloadNuGet OutputFilename="$(NuGetExePath)"
 			Condition="'$(OS)' == 'Windows_NT'" />
-		<Exec Command="wget https://nuget.org/NuGet.exe || curl -O -L wget https://nuget.org/NuGet.exe"
+		<Exec Command="wget https://nuget.org/NuGet.exe || curl -O -L https://nuget.org/NuGet.exe"
 			WorkingDirectory="$(NuGetToolsPath)"
 			Condition="'$(OS)' != 'Windows_NT'" />
 	</Target>

--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,10 @@ Section: misc
 Priority: extra
 Maintainer: Stephen McConnel <stephen_mcconnel@sil.org>
 Build-Depends: debhelper (>= 8.0.0),
+ cli-common-dev (>= 0.8~),
  mono-sil, libgdiplus-sil,
- cli-common-dev,
- geckofx29, unzip, wget,
- pkg-config,
- curl,
- ca-certificates,
- adduser (>= 3.11)
+ libenchant-dev, libxklavier-dev, libgtk2.0-dev,
+ geckofx29, unzip, curl, ca-certificates
 Standards-Version: 3.9.2
 Homepage: http://projects.palaso.org/projects/fwbridge
 #Vcs-Git: git://git.debian.org/collab-maint/flexbridge.git
@@ -17,10 +14,11 @@ Homepage: http://projects.palaso.org/projects/fwbridge
 
 Package: flexbridge
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7), python (<< 2.8),
- mono-sil, libgdiplus-sil, libgtk2.0-dev, libgtkmm-2.4-1c2a, libgtkmm-2.4-dev,
- libgtksourceview2.0-0, libgtksourceview2.0-common, geckofx29, unzip,
- fieldworks-applications (>> 8.1.9)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${cli:Depends},
+ mono-sil, libgdiplus-sil,
+ fieldworks-applications (>> 8.1.9),
+ python (>= 2.7), python (<< 2.8),
+ geckofx29, unzip, adduser (>= 3.11)
 Description: Allow multiple FieldWorks users to collaborate remotely
  FLEx Bridge is an application that allows multiple FieldWorks 8.0 users
  to do remote collaboration (i.e., not necessarily connected by a local

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Build-Depends: debhelper (>= 8.0.0),
  geckofx29, unzip, curl, ca-certificates
 Standards-Version: 3.9.6
 Homepage: http://projects.palaso.org/projects/fwbridge
-#Vcs-Git: git://git.debian.org/collab-maint/flexbridge.git
-#Vcs-Browser: http://git.debian.org/?p=collab-maint/flexbridge.git;a=summary
+Vcs-Git: https://github.com/sillsdev/flexbridge.git
+Vcs-Browser: https://github.com/sillsdev/flexbridge
 
 Package: flexbridge
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -7,14 +7,14 @@ Build-Depends: debhelper (>= 8.0.0),
  mono-sil, libgdiplus-sil,
  libenchant-dev, libxklavier-dev, libgtk2.0-dev,
  geckofx29, unzip, curl, ca-certificates
-Standards-Version: 3.9.2
+Standards-Version: 3.9.6
 Homepage: http://projects.palaso.org/projects/fwbridge
 #Vcs-Git: git://git.debian.org/collab-maint/flexbridge.git
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/flexbridge.git;a=summary
 
 Package: flexbridge
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${cli:Depends},
+Architecture: all
+Depends: ${misc:Depends}, ${cli:Depends},
  mono-sil, libgdiplus-sil,
  fieldworks-applications (>> 8.1.9),
  python (>= 2.7), python (<< 2.8),

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,10 +1,10 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Name: flexbridge
-Source: http://projects.palaso.org/projects/fwbridge
+Source: https://github.com/sillsdev/flexbridge
 
 Files: *
 Copyright: 2013-2015, SIL International, Inc. All rights reserved.
-License: MIT License
+License: MIT
  FLExBridge is copyrighted under the MIT License. This can be found at
  http://opensource.org/licenses/MIT
  .

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,12 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
 %:
-	dh $@
+	dh $@ --with cli
+
+override_dh_clideps:
+	dh_clideps \
+		--exclude-moduleref=icuuc48.dll \
+		--exclude-moduleref=icuin48.dll

--- a/download_dependencies_linux.sh
+++ b/download_dependencies_linux.sh
@@ -53,10 +53,14 @@ fi
 
 copy_wget() {
 echo "wget: $2 <= $1"
-f=$(basename $2)
-d=$(dirname $2)
-cd $d
+f1=$(basename $1)
+f2=$(basename $2)
+cd $(dirname $2)
 wget -q -L -N $1
+# wget has no true equivalent of curl's -o option.
+# Different versions of wget handle (or not) % escaping differently.
+# A URL query is the only reason why $f1 and $f2 should differ.
+if [ "$f1" != "$f2" ]; then mv $f2\?* $f2; fi
 cd -
 }
 
@@ -130,34 +134,34 @@ cd -
 #     revision: latest.lastSuccessful
 #     paths: {"L10NSharp.dll"=>"lib/DebugMono"}
 #     VCS: https://bitbucket.org/sillsdev/l10nsharp []
-# [9] build: icucil-precise64-Continuous (bt281)
+# [9] build: palaso-precise64-libpalaso-2.6 Continuous (PalasoPrecise64v26Cont)
+#     project: libpalaso
+#     URL: http://build.palaso.org/viewType.html?buildTypeId=PalasoPrecise64v26Cont
+#     clean: false
+#     revision: latest.lastSuccessful
+#     paths: {"Palaso.dll"=>"lib/ReleaseMono", "Palaso.TestUtilities.dll"=>"lib/ReleaseMono", "PalasoUIWindowsForms.dll"=>"lib/ReleaseMono", "PalasoUIWindowsForms.dll.config"=>"lib/ReleaseMono", "PalasoUIWindowsForms.GeckoBrowserAdapter.dll"=>"lib/ReleaseMono", "Palaso.Lift.dll"=>"lib/ReleaseMono"}
+#     VCS: https://github.com/sillsdev/libpalaso.git [libpalaso-2.6]
+# [10] build: palaso-precise64-libpalaso-2.6 Continuous (PalasoPrecise64v26Cont)
+#     project: libpalaso
+#     URL: http://build.palaso.org/viewType.html?buildTypeId=PalasoPrecise64v26Cont
+#     clean: false
+#     revision: latest.lastSuccessful
+#     paths: {"debug/Palaso.dll"=>"lib/DebugMono", "debug/Palaso.TestUtilities.dll"=>"lib/DebugMono", "debug/PalasoUIWindowsForms.dll"=>"lib/DebugMono", "debug/PalasoUIWindowsForms.dll.config"=>"lib/DebugMono", "debug/PalasoUIWindowsForms.GeckoBrowserAdapter.dll"=>"lib/DebugMono", "debug/Palaso.Lift.dll"=>"lib/DebugMono"}
+#     VCS: https://github.com/sillsdev/libpalaso.git [libpalaso-2.6]
+# [11] build: icucil-precise64-Continuous (bt281)
 #     project: Libraries
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt281
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"icu*.dll"=>"lib/ReleaseMono", "icu*.config"=>"lib/ReleaseMono"}
 #     VCS: https://github.com/sillsdev/icu-dotnet [master]
-# [10] build: icucil-precise64-Continuous (bt281)
+# [12] build: icucil-precise64-Continuous (bt281)
 #     project: Libraries
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt281
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"icu*.dll"=>"lib/DebugMono", "icu*.config"=>"lib/DebugMono"}
 #     VCS: https://github.com/sillsdev/icu-dotnet [master]
-# [11] build: palaso-precise64-libpalaso-2.6 Continuous (PalasoPrecise64v26Cont)
-#     project: libpalaso
-#     URL: http://build.palaso.org/viewType.html?buildTypeId=PalasoPrecise64v26Cont
-#     clean: false
-#     revision: latest.lastSuccessful
-#     paths: {"Palaso.dll"=>"lib/ReleaseMono", "Palaso.TestUtilities.dll"=>"lib/ReleaseMono", "PalasoUIWindowsForms.dll"=>"lib/ReleaseMono", "PalasoUIWindowsForms.GeckoBrowserAdapter.dll"=>"lib/ReleaseMono", "Palaso.Lift.dll"=>"lib/ReleaseMono"}
-#     VCS: https://github.com/sillsdev/libpalaso.git [libpalaso-2.6]
-# [12] build: palaso-precise64-libpalaso-2.6 Continuous (PalasoPrecise64v26Cont)
-#     project: libpalaso
-#     URL: http://build.palaso.org/viewType.html?buildTypeId=PalasoPrecise64v26Cont
-#     clean: false
-#     revision: latest.lastSuccessful
-#     paths: {"debug/Palaso.dll"=>"lib/DebugMono", "debug/Palaso.TestUtilities.dll"=>"lib/DebugMono", "debug/PalasoUIWindowsForms.dll"=>"lib/DebugMono", "debug/PalasoUIWindowsForms.GeckoBrowserAdapter.dll"=>"lib/DebugMono", "debug/Palaso.Lift.dll"=>"lib/DebugMono"}
-#     VCS: https://github.com/sillsdev/libpalaso.git [libpalaso-2.6]
 
 # make sure output directories exist
 mkdir -p ./MercurialExtensions
@@ -206,18 +210,20 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt279/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt279/latest.lastSuccessful/IPCFramework.dll ./lib/DebugMono/IPCFramework.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt271/latest.lastSuccessful/L10NSharp.dll ./lib/ReleaseMono/L10NSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt271/latest.lastSuccessful/L10NSharp.dll ./lib/DebugMono/L10NSharp.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll ./lib/ReleaseMono/icu.net.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll.config ./lib/ReleaseMono/icu.net.dll.config
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll ./lib/DebugMono/icu.net.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll.config ./lib/DebugMono/icu.net.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/Palaso.dll?branch=%3Cdefault%3E ./lib/ReleaseMono/Palaso.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/Palaso.TestUtilities.dll?branch=%3Cdefault%3E ./lib/ReleaseMono/Palaso.TestUtilities.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/PalasoUIWindowsForms.dll?branch=%3Cdefault%3E ./lib/ReleaseMono/PalasoUIWindowsForms.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/PalasoUIWindowsForms.dll.config?branch=%3Cdefault%3E ./lib/ReleaseMono/PalasoUIWindowsForms.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/PalasoUIWindowsForms.GeckoBrowserAdapter.dll?branch=%3Cdefault%3E ./lib/ReleaseMono/PalasoUIWindowsForms.GeckoBrowserAdapter.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/Palaso.Lift.dll?branch=%3Cdefault%3E ./lib/ReleaseMono/Palaso.Lift.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/Palaso.dll?branch=%3Cdefault%3E ./lib/DebugMono/Palaso.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/Palaso.TestUtilities.dll?branch=%3Cdefault%3E ./lib/DebugMono/Palaso.TestUtilities.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/PalasoUIWindowsForms.dll?branch=%3Cdefault%3E ./lib/DebugMono/PalasoUIWindowsForms.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/PalasoUIWindowsForms.dll.config?branch=%3Cdefault%3E ./lib/DebugMono/PalasoUIWindowsForms.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/PalasoUIWindowsForms.GeckoBrowserAdapter.dll?branch=%3Cdefault%3E ./lib/DebugMono/PalasoUIWindowsForms.GeckoBrowserAdapter.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/PalasoPrecise64v26Cont/latest.lastSuccessful/debug/Palaso.Lift.dll?branch=%3Cdefault%3E ./lib/DebugMono/Palaso.Lift.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll ./lib/ReleaseMono/icu.net.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll.config ./lib/ReleaseMono/icu.net.dll.config
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll ./lib/DebugMono/icu.net.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt281/latest.lastSuccessful/icu.net.dll.config ./lib/DebugMono/icu.net.dll.config
 # End of script

--- a/download_dependencies_windows.sh
+++ b/download_dependencies_windows.sh
@@ -53,10 +53,14 @@ fi
 
 copy_wget() {
 echo "wget: $2 <= $1"
-f=$(basename $2)
-d=$(dirname $2)
-cd $d
+f1=$(basename $1)
+f2=$(basename $2)
+cd $(dirname $2)
 wget -q -L -N $1
+# wget has no true equivalent of curl's -o option.
+# Different versions of wget handle (or not) % escaping differently.
+# A URL query is the only reason why $f1 and $f2 should differ.
+if [ "$f1" != "$f2" ]; then mv $f2\?* $f2; fi
 cd -
 }
 


### PR DESCRIPTION
The main purpose is to switch to using automatic dependency generation, but a few other things are tidied up in the process. In particular, the package now builds successfully for 16.04 (Xenial).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/79)
<!-- Reviewable:end -->
