### PR TITLE
Added some more exception info

### DIFF
--- a/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/SendReceiveActionHandler.cs
@@ -4,6 +4,7 @@
 // Distributable under the terms of the MIT License, as specified in the license.rtf file.
 // --------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
@@ -11,6 +12,7 @@ using System.Windows.Forms;
 using Chorus.UI.Sync;
 using FLEx_ChorusPlugin.Infrastructure.DomainServices;
 using FLEx_ChorusPlugin.Properties;
+using Palaso.Reporting;
 using TriboroughBridge_ChorusPlugin;
 using TriboroughBridge_ChorusPlugin.Infrastructure;
 
@@ -113,11 +115,11 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 				}
 				finally
 				{
-					SafelyDeleteDictConfigXsd(tempXsdPath);
 					if (File.Exists(lockPathname))
 						File.Delete(lockPathname);
 				}
 			}
+			SafelyDeleteDictConfigXsd(tempXsdPath);
 		}
 
 		private static string EnsureAccessToDictionaryConfigXsd(IDictionary<string, string> commandLineArgs)
@@ -128,7 +130,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 			if (!File.Exists(xsdPath))
 				xsdPath = Path.Combine(fwAppsDir, "..", "..", "DistFiles", innerXsdPath);
 			if (!File.Exists(xsdPath))
-				return string.Empty;
+				throw new FileNotFoundException(string.Format("Expected to find {0} at {1}" + Environment.NewLine + "fwAppsDir is {2}", SharedConstants.DictConfigSchemaFilename, xsdPath, fwAppsDir));
 			var xsdDirInProject = Path.Combine(Path.GetDirectoryName(commandLineArgs["-p"]), "Temp");
 			if (!Directory.Exists(xsdDirInProject))
 				Directory.CreateDirectory(xsdDirInProject);
@@ -143,6 +145,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 			if (!File.Exists(xsdPath))
 				return;
 			File.SetAttributes(xsdPath, FileAttributes.Normal);
+			Logger.WriteEvent(string.Format("Deleting {0} from {1}", SharedConstants.DictConfigSchemaFilename, xsdPath));
 			File.Delete(xsdPath);
 		}
 

--- a/src/FLEx-ChorusPlugin/Infrastructure/Handling/ConfigLayout/DictionaryConfigurationHandlerStrategy.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/Handling/ConfigLayout/DictionaryConfigurationHandlerStrategy.cs
@@ -35,7 +35,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.Handling.ConfigLayout
 					return _xsdPath;
 				parentDir = Path.GetDirectoryName(parentDir);
 			}
-			throw new FileNotFoundException(string.Format("Could not find the Dictionary Configuration Schema file looking in {0}", configFilePath), SharedConstants.DictConfigSchemaFilename);
+			throw new FileNotFoundException(string.Format("Could not find the Dictionary Configuration Schema file in or upstream from {0}", configFilePath), SharedConstants.DictConfigSchemaFilename);
 		}
 
 		public bool CanValidateFile(string pathToFile)


### PR DESCRIPTION
* throw an exception if the xsd file is not found
* moved the delete down farther in case the xsd file
  was being deleted too soon.
* Log when xsd in Temp folder is deleted

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/82)
<!-- Reviewable:end -->
