### PR TITLE
LT-17100: Uninstall FLExBridge before installing

### DIFF
--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -26,7 +26,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 	<WixVariable Id="WixUIDialogBmp" Value="DialogBGWithSILLogo.bmp" />
 
 	<!-- Using afterInstallFinalize will allow the apparent downgrading of files in the Chorus merge module. -->
-	<MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
+	<MajorUpgrade AllowSameVersionUpgrades="yes" AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
 
 	<Property Id="MANUFACTURERREGKEY">SIL</Property>
 	<!-- The following will set properties A[FW8INSTALLDIR] and B[FW8DEVINSTALLDIR] to the result of two different registry searches.


### PR DESCRIPTION
When the first three version numbers and the Upgrade Code match,
but the Prouct Code does not, MSI allows installing both versions
as "separate products." This is not good. AllowSameVersionUpgrades
interprets installing these "same versions" as an "upgrade,"
therefore properly removing the installed version before installing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/86)
<!-- Reviewable:end -->
