### PR TITLE
Allow Passing Version to the Installer Builder as a Property

### DIFF
--- a/build/FLExBridge.build.win.proj
+++ b/build/FLExBridge.build.win.proj
@@ -74,7 +74,8 @@
 
   <!-- For use when working on installer development -->
   <!-- To build the installer from the build folder to build on a developer machine use something similar to the following: -->
-  <!-- msbuild FLExBridge.build.win.proj /t:DevelopInstaller /p:BuildCounter=99 /p:BUILD_VCS_NUMBER=24445 /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=none /p:UploadFolder=Alpha/p:Configuration=Release /p:Platform="Any CPU" -->
+  <!-- msbuild FLExBridge.build.win.proj /t:DevelopInstaller /p:Version=2.4.0 /p:BUILD_VCS_NUMBER=24445 /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=none /p:UploadFolder=Alpha/p:Configuration=Release /p:Platform="Any CPU" -->
+  <!-- If no Version is specified, reads from "$(RootDir)/version". -->
   <Target Name="DevelopInstaller" DependsOnTargets="VersionNumbers; CreateDirectories; Build">
 	<Copy SourceFiles="$(RootDir)\src\Installer\Installer.wxs" DestinationFolder="$(RootDir)\output\Installer"/>
 	<FileUpdate File="$(RootDir)\src\Installer\Installer.wxs" Regex="Property_ProductVersion = &quot;.*&quot;" ReplacementText="Property_ProductVersion = &quot;$(Version)&quot;"/>

--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -4,7 +4,8 @@
   <Import Project="$(RootDir)\build\NuGet.targets"/>
 
   <Target Name="VersionNumbers">
-    <ReadLinesFromFile File="$(RootDir)/version">
+	<Message Text="Version Property: $(Version)" Importance="high"/>
+    <ReadLinesFromFile Condition="'$(Version)' == ''" File="$(RootDir)/version">
         <Output TaskParameter="Lines" PropertyName="Version" />
     </ReadLinesFromFile>
 	<Message Text="Version: $(Version)" Importance="high"/>

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -26,7 +26,7 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 	<WixVariable Id="WixUIDialogBmp" Value="DialogBGWithSILLogo.bmp" />
 
 	<!-- Using afterInstallFinalize will allow the apparent downgrading of files in the Chorus merge module. -->
-	<MajorUpgrade AllowSameVersionUpgrades="yes" AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
+	<MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
 
 	<Property Id="MANUFACTURERREGKEY">SIL</Property>
 	<!-- The following will set properties A[FW8INSTALLDIR] and B[FW8DEVINSTALLDIR] to the result of two different registry searches.


### PR DESCRIPTION
Changes in FLExBridge code:
- If the Version Property is set, use it; otherwise, read from the
Version file
- Update instructional comment on DevelopInstaller target
- Revert AllowSameVersionUpgrades

Changes in TeamCity:
- set `system.Version=2.4.%build.counter%`
- set Build number format: `%system.Version%.{build.vcs.number.1}`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="20" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/87)
<!-- Reviewable:end -->
