### PR TITLE
Use RepositoryAddress.Create to create repo path

### DIFF
--- a/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
@@ -87,7 +87,8 @@ namespace LfMergeBridge
 				CheckinDescription = string.Format("[{0}: {1}] sync", assemblyName.Name, assemblyName.Version)
 			};
 			syncOptions.RepositorySourcesToTry.Clear(); // Get rid of any default ones, since LF only sends off to the internet (Language Depot).
-			syncOptions.RepositorySourcesToTry.Add(new HttpRepositoryPath(options[LfMergeBridgeUtilities.LanguageDepotRepoNameKey], options[LfMergeBridgeUtilities.LanguageDepotRepoUriKey], false));
+			// We use the generic creation code here to make testing easier. In the real world we will only create "HttpRepositoryPath".
+			syncOptions.RepositorySourcesToTry.Add(RepositoryAddress.Create(options[LfMergeBridgeUtilities.LanguageDepotRepoNameKey], options[LfMergeBridgeUtilities.LanguageDepotRepoUriKey], false));
 
 			var syncResults = synchronizer.SyncNow(syncOptions);
 			if (!syncResults.Succeeded)


### PR DESCRIPTION
When running tests in LfMerge we use a directory rather than a remote URL, so we need to create the proper RepositoryAddress which the Create() method takes care of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/97)
<!-- Reviewable:end -->
