### PR TITLE
Include all architectures of mercurial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ install: release
 	/bin/chmod -x $(DESTDIR)/usr/lib/flexbridge/*.md*
 	/usr/bin/install lib/common/setup-user.sh $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install lib/common/run-app $(DESTDIR)/usr/lib/flexbridge
-	/usr/bin/install -m644 lib/ReleaseMono/Mercurial-$(CPUARCH).zip $(DESTDIR)/usr/lib/flexbridge
+	# Copy mercurial for both architectures since flexbridge is an any architecture package.
+	/usr/bin/install -m644 lib/ReleaseMono/Mercurial-x86_64.zip $(DESTDIR)/usr/lib/flexbridge
+	/usr/bin/install -m644 lib/ReleaseMono/Mercurial-i686.zip $(DESTDIR)/usr/lib/flexbridge
 	cp -r MercurialExtensions $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install lib/common/Chorus_Help.chm $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install lib/common/chorusmerge $(DESTDIR)/usr/lib/flexbridge


### PR DESCRIPTION
flexbridge is packaged as an any architecture package. So since it
bundles Mercurial, it needs to bundle both Mercurial architectures so
it can run on machines of either architecture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/104)
<!-- Reviewable:end -->
