### PR TITLE
[LfMergeBridge] Don't delete repo if no such branch

### DIFF
--- a/src/LfMergeBridge/LfMergeBridgeUtilities.cs
+++ b/src/LfMergeBridge/LfMergeBridgeUtilities.cs
@@ -19,6 +19,7 @@ namespace LfMergeBridge
 		internal const string languageDepotRepoName = "languageDepotRepoName";
 		internal const string fdoDataModelVersion = "fdoDataModelVersion";
 		internal const string user = "user";
+		internal const string deleteRepoIfNoSuchBranch = "deleteRepoIfNoSuchBranch";
 		internal const string commitMessage = "commitMessage";
 
 		internal const string failure = "failure";


### PR DESCRIPTION
Let LfMerge deal with deleting repo if the desired branch doesn't
exist. This allows to support multiple database model version
without having to re-clone the repo. The change is backwards
compatible; unless the new option "deleteRepoIfNoSuchBranch" is set
to false nothing will change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/119)
<!-- Reviewable:end -->
