### PR TITLE
Improve error messages for invalid attributes in CmObjects

### DIFF
--- a/src/FLEx-ChorusPlugin/Infrastructure/DomainServices/CmObjectValidator.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/DomainServices/CmObjectValidator.cs
@@ -414,9 +414,14 @@ namespace FLEx_ChorusPlugin.Infrastructure.DomainServices
 			if (propElement == null)
 				return null;
 			var set = attrs;
-			return propElement.Attributes().Any(attr => !set.Contains(attr.Name.LocalName))
-				? string.Format("Invalid attribute for <{0}> element", propElement.Name.LocalName)
-				: null;
+			var invalidAttributes = from attr in propElement.Attributes() where !set.Contains(attr.Name.LocalName) select attr;
+			var xAttributes = invalidAttributes as XAttribute[] ?? invalidAttributes.ToArray();
+			if (xAttributes.Any())
+			{
+				return string.Format("Element <{0}> has invalid attribute(s) '{1}'", propElement.Name.LocalName,
+					string.Join("', '", from el in xAttributes select el.Name.LocalName));
+			}
+			return null;
 		}
 
 		private static string ValidateBinaryProperty(bool isCustomProperty, XElement propertyElement)

--- a/src/FLEx-ChorusPluginTests/Infrastructure/DomainServices/CmObjectValidatorTests.cs
+++ b/src/FLEx-ChorusPluginTests/Infrastructure/DomainServices/CmObjectValidatorTests.cs
@@ -418,7 +418,7 @@ namespace FLEx_ChorusPluginTests.Infrastructure.DomainServices
 			runElement.Add(badAttr);
 			result = CmObjectValidator.ValidateObject(_mdc, element);
 			Assert.IsNotNull(result);
-			Assert.IsTrue(result.Contains("Invalid attribute for <Run> element"));
+			Assert.IsTrue(result.Contains("Element <Run> has invalid attribute(s) 'bogusAttr'"));
 			badAttr.Remove();
 		}
 


### PR DESCRIPTION
* There is a bug in FLEx somewhere that lets the user create a Run
  with a bad attribute. Tracking down what the attribute was lead
  to the desire for this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/120)
<!-- Reviewable:end -->
