### PR TITLE
Change FB execution script for linux

### DIFF
--- a/DistFiles/localizations/Chorus.en.tmx
+++ b/DistFiles/localizations/Chorus.en.tmx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
   <header srclang="en" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="1.2.54.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
-    <prop type="x-appversion">2.5.1067</prop>
+    <prop type="x-appversion">2.5.1068</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
   <body>

--- a/DistFiles/localizations/Chorus.es.tmx
+++ b/DistFiles/localizations/Chorus.es.tmx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
   <header srclang="es" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="2.0.6.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
-    <prop type="x-appversion">2.5.1067</prop>
+    <prop type="x-appversion">2.5.1068</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
   <body>

--- a/DistFiles/localizations/Chorus.fr.tmx
+++ b/DistFiles/localizations/Chorus.fr.tmx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
   <header srclang="fr" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="2.0.6.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
-    <prop type="x-appversion">2.5.1067</prop>
+    <prop type="x-appversion">2.5.1068</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
   <body>

--- a/DistFiles/localizations/Chorus.zh-Hans.tmx
+++ b/DistFiles/localizations/Chorus.zh-Hans.tmx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
   <header srclang="zh-Hans" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="2.0.6.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
-    <prop type="x-appversion">2.5.1067</prop>
+    <prop type="x-appversion">2.5.1068</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
   <body>

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ all: release
 
 release: vcs_version
 	./download_dependencies_linux.sh && . ./environ && cd build && xbuild FLExBridge.build.mono.proj /t:Build /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=notthere /p:BUILD_NUMBER=$(BUILD_NUMBER) /p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) /p:Configuration=ReleaseMono /v:debug
-	cp -a run-in-environ environ environ-xulrunner output/ReleaseMono
+	cp -a flexbridge environ environ-xulrunner output/ReleaseMono
 
 debug: vcs_version
 	FBCommonAppData="/tmp/flexbridge"
 	if test ! -d "/tmp/flexbridge"; then mkdir -p "/tmp/flexbridge"; fi;
 	export FBCommonAppData
 	./download_dependencies_linux.sh && . ./environ && cd build && xbuild FLExBridge.build.mono.proj /t:Build /p:RootDir=.. /p:teamcity_dotnet_nunitlauncher_msbuild_task=notthere /p:BUILD_NUMBER=$(BUILD_NUMBER) /p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) /p:Configuration=DebugMono
-	# Put run-in-environment next to FLExBridge.exe, as it will be in a user's machine, so FW can easily find it on a developer's machine.
-	cp -a run-in-environ environ environ-xulrunner output/DebugMono
+	# Put flexbridge next to FLExBridge.exe, as it will be in a user's machine, so FW can easily find it on a developer's machine.
+	cp -a flexbridge environ environ-xulrunner output/DebugMono
 
 # generate the vcs_version file, this hash is used to update the about.htm information
 vcs_version:
@@ -36,7 +36,7 @@ install:
 	/bin/chmod -x $(DESTDIR)/usr/lib/flexbridge/*.png
 	/bin/chmod -x $(DESTDIR)/usr/lib/flexbridge/*.config
 	/bin/chmod -x $(DESTDIR)/usr/lib/flexbridge/*.md*
-	/usr/bin/install environ environ-xulrunner run-in-environ $(DESTDIR)/usr/lib/flexbridge
+	/usr/bin/install flexbridge environ environ-xulrunner $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install lib/common/setup-user.sh $(DESTDIR)/usr/lib/flexbridge
 	/usr/bin/install lib/common/run-app $(DESTDIR)/usr/lib/flexbridge
 	# Copy mercurial for both architectures since flexbridge is an any architecture package.

--- a/flexbridge
+++ b/flexbridge
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Launch FlexBridge
+
+set -e -o pipefail
+
+scriptdir="$(dirname "$0")"
+prefix=$(cd "$scriptdir/../.."; /bin/pwd)
+
+cd "${scriptdir}"
+. environ
+
+(
+	XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME}/.local/share}
+	FB_SHARE="${XDG_DATA_HOME}/SIL/FlexBridge"
+
+	# Keep localizations files updated.
+	# Initialize on fresh install
+	if [ ! -f "${FB_SHARE}" ]; then
+		mkdir -p "${FB_SHARE}"
+	fi
+	
+	# update new localizations
+	if [ "${prefix}" == "/usr" ];then
+		cp -a "/var/lib/flexbridge/localizations" "${FB_SHARE}"
+	else
+		# For developer build. This is still not working correctly.
+		cp -a "${prefix}/DistFiles/localizations" "${FB_SHARE}"
+	fi
+)
+
+cd - >/dev/null
+"${scriptdir}"/FLExBridge.exe "$@"

--- a/run-in-environ
+++ b/run-in-environ
@@ -3,32 +3,7 @@
 # Run command in environment
 
 set -e -o pipefail
-
-scriptdir="$(dirname "$0")"
-prefix=$(cd "$scriptdir/../.."; /bin/pwd)
-
 cd "$(dirname "$0")"
 . environ
-
-(
-	XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME}/.local/share}
-	FB_SHARE="${XDG_DATA_HOME}/SIL/FlexBridge"
-
-	# Keep localizations files updated.
-	# Initialize on fresh install
-	if [ ! -f "${FB_SHARE}" ]; then
-		mkdir -p "${FB_SHARE}"
-	fi
-	
-	# update new localizations
-	if [ "${prefix}" == "/usr" ];then
-		cp -a "/var/lib/flexbridge/localizations" "${FB_SHARE}"
-	else
-		# For developer build. This is still not working correctly.
-		cp -a "${prefix}/DistFiles/localizations" "${FB_SHARE}"
-	fi
-		
-)
-
 cd - >/dev/null
 "$@"


### PR DESCRIPTION
Change execution script from run-in-environ to flexbridge.
Keep run-in-environ for developer purposes.
Cleanup Makefile to include the flexbridge file.
Update Chorus*.tmx localization files to version 2.5.1068.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/126)
<!-- Reviewable:end -->
