### PR TITLE
Specify mono when executing FLExBridge.exe

### DIFF
--- a/flexbridge
+++ b/flexbridge
@@ -30,4 +30,4 @@ cd "${scriptdir}"
 )
 
 cd - >/dev/null
-"${scriptdir}"/FLExBridge.exe "$@"
+mono "${scriptdir}"/FLExBridge.exe "$@"


### PR DESCRIPTION
To make sure we run the right mono without relying on binfmt choosing
the right one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/129)
<!-- Reviewable:end -->
