### PR TITLE
Update DateModified when doing a merge

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Handling/PreferMostRecentTimePreMerger.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/PreferMostRecentTimePreMerger.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) 2010-2016 SIL International
+﻿// Copyright (c) 2010-2017 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT) (See: license.rtf file)
 
 using System;
-using System.Globalization;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using Chorus.merge.xml.generic;
 
@@ -24,26 +26,40 @@ namespace LibFLExBridgeChorusPlugin.Handling
 	{
 		void IPremerger.Premerge(IMergeEventListener listener, ref XmlNode ourDateTimeNode, XmlNode theirDateTimeNode, XmlNode ancestorDateTimeNode)
 		{
-			RestoreOriginalIfTimestampIsTheOnlyChange(ancestorDateTimeNode, ourDateTimeNode);
-			RestoreOriginalIfTimestampIsTheOnlyChange(ancestorDateTimeNode, theirDateTimeNode);
+			var ourOnlyTimestampChange = RestoreOriginalIfTimestampIsTheOnlyChange(ancestorDateTimeNode, ourDateTimeNode);
+			var theirOnlyTimestampChange = RestoreOriginalIfTimestampIsTheOnlyChange(ancestorDateTimeNode, theirDateTimeNode);
 
-			var newest = DateTime.MinValue.ToString(CultureInfo.InvariantCulture);
-			newest = GetMostRecentVal(newest, ourDateTimeNode);
-			newest = GetMostRecentVal(newest, theirDateTimeNode);
-			UpdateDateTimeVal(newest, ourDateTimeNode);
-			UpdateDateTimeVal(newest, theirDateTimeNode);
+			DateTime newestDateTime;
+			if (ourOnlyTimestampChange && theirOnlyTimestampChange)
+			{
+				// timestamp was the only change. Use the newer timestamp.
+				newestDateTime = DateTime.MinValue;
+				newestDateTime = GetMostRecentVal(newestDateTime, ourDateTimeNode);
+				newestDateTime = GetMostRecentVal(newestDateTime, theirDateTimeNode);
+			}
+			else
+			{
+				// something else besides the timestamp changed. Set timestamp to current time.
+				newestDateTime = DateTime.UtcNow;
+			}
+			var newestDateTimeString = newestDateTime.ToString("yyyy-M-d H:m:s.FFF");
+			UpdateDateTimeVal(newestDateTimeString, ourDateTimeNode);
+			UpdateDateTimeVal(newestDateTimeString, theirDateTimeNode);
 		}
 
-		private static void RestoreOriginalIfTimestampIsTheOnlyChange(XmlNode ancestorDateTimeNode, XmlNode otherDateTimeNode)
+		private static bool RestoreOriginalIfTimestampIsTheOnlyChange(XmlNode ancestorDateTimeNode, XmlNode otherDateTimeNode)
 		{
-			if (ancestorDateTimeNode == null || otherDateTimeNode == null)
-				return;
+			if (ancestorDateTimeNode == null)
+				return false;
+
+			if (otherDateTimeNode == null)
+				return true;
 
 			// Values that are are the same are not of interest.
 			var ancestorAttr = ancestorDateTimeNode.Attributes["val"];
 			var otherAttr = otherDateTimeNode.Attributes["val"];
 			if (ancestorAttr.Value == otherAttr.Value)
-				return;
+				return true;
 
 			// Get parents of both nodes
 			var ancestorDateTimeNodeParent = ancestorDateTimeNode.ParentNode;
@@ -54,10 +70,11 @@ namespace LibFLExBridgeChorusPlugin.Handling
 			otherAttr.Value = ancestorAttr.Value;
 
 			if (XmlUtilities.AreXmlElementsEqual(ancestorDateTimeNodeParent, otherDateTimeNodeParent))
-				return; // Only change was the timestamp, so keep it.
+				return true; // Only change was the timestamp, so keep it.
 
 			// Restore the original value.
 			otherAttr.Value = originalOtherValue;
+			return false;
 		}
 
 		private static void UpdateDateTimeVal(string newest, XmlNode currentDateTimeNode)
@@ -68,16 +85,15 @@ namespace LibFLExBridgeChorusPlugin.Handling
 			elt.SetAttribute("val", newest);
 		}
 
-		private static string GetMostRecentVal(string newest, XmlNode currentDateTimeNode)
+		private static DateTime GetMostRecentVal(DateTime date1, XmlNode currentDateTimeNode)
 		{
 			if (currentDateTimeNode == null)
-				return newest;
-			DateTime date1;
+				return date1;
+			DateTime date2;
 			var date1String = XmlUtilities.GetStringAttribute(currentDateTimeNode, "val");
-			if (!DateTime.TryParse(date1String, out date1))
-				return newest;
-			var date2 = DateTime.Parse(newest);
-			return (date1 > date2) ? date1String : newest;
+			if (!DateTime.TryParse(date1String, out date2))
+				return date1;
+			return (date2 > date1) ? date2 : date1;
 		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/BaseFieldWorksTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/BaseFieldWorksTypeHandlerTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT) (See: license.rtf file)
 
+using System;
+using System.Xml;
 using Chorus.FileTypeHandlers;
 using LibFLExBridgeChorusPlugin.Infrastructure;
 using NUnit.Framework;
@@ -34,6 +36,25 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 		public virtual void TestTearDown()
 		{
 			Mdc = null;
+		}
+
+		public static string GetXPathNodeFrom(string xml, string xpath)
+		{
+			var doc = new XmlDocument();
+			doc.LoadXml(xml);
+			var nodes = doc.SelectNodes(xpath);
+			if (nodes != null && nodes.Count == 1)
+				return nodes[0].InnerXml;
+			return string.Empty;
+		}
+
+		public static string DateTimeNowString
+		{
+			get
+			{
+				var dateTimeNow = DateTime.UtcNow.ToString("yyyy-M-d H:m:s.FFF");
+				return dateTimeNow;
+			}
 		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/DateTimeMergingTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/DateTimeMergingTests.cs
@@ -7,10 +7,10 @@ using System.Xml;
 using Chorus.FileTypeHandlers.xml;
 using Chorus.merge.xml.generic;
 using LibChorus.TestUtilities;
+using LibFLExBridgeChorusPlugin.Handling;
+using LibFLExBridgeChorusPlugin.Infrastructure;
 using NUnit.Framework;
 using Palaso.IO;
-using LibFLExBridgeChorusPlugin.Infrastructure;
-using LibFLExBridgeChorusPlugin.Handling;
 
 namespace LibFLExBridgeChorusPluginTests.Handling
 {
@@ -35,66 +35,52 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 			FieldWorksTestServices.RemoveTempFilesAndParentDir(ref _ourFile, ref _commonFile, ref _theirFile);
 		}
 
+		private const string CommonOwnSeqAncestor =
+			@"<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
+	<DateModified val='2000-1-1 23:59:59.123' />
+	<Name>
+			<AUni
+				ws='en'>commonName</AUni>
+	</Name>
+</ownseq>";
+
 		[Test]
 		public void OurOriginalTimestampRestoredToAncestorValueIfOnlyChangeWasTimestampAndTheyDeletedParent()
 		{
-			const string commonAncestor =
-@"<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-	<DateModified val='2000-1-1 23:59:59.000' />
-	<Name>
-			<AUni
-				ws='en'>commonName</AUni>
-	</Name>
-</ownseq>";
-			var ourContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000");
+			var ourContent = CommonOwnSeqAncestor.Replace("2000-1-1 23:59:59.123", "2002-1-1 23:59:59.123");
 
-			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(commonAncestor, new XmlDocument());
+			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(CommonOwnSeqAncestor, new XmlDocument());
 			var ancestorModPropNode = ancestorNode.SelectSingleNode("DateModified");
 			var ourNode = XmlUtilities.GetDocumentNodeFromRawXml(ourContent, new XmlDocument());
 			var ourModPropNode = ourNode.SelectSingleNode("DateModified");
 			IPremerger premerger = new PreferMostRecentTimePreMerger();
 			premerger.Premerge(new ListenerForUnitTests(), ref ourModPropNode, null, ancestorModPropNode);
 
-			Assert.AreEqual("2000-1-1 23:59:59.000", ourModPropNode.Attributes["val"].Value);
+			Assert.AreEqual("2000-1-1 23:59:59.123", ourModPropNode.Attributes["val"].Value);
 		}
 
 		[Test]
-		public void OurOriginalTimestampKeptIfAnotherChangedWasMadeAndTheyDeletedParent()
+		public void TimestampUpdatedIfAnotherChangedWasMadeAndTheyDeletedParent()
 		{
-			const string commonAncestor =
-@"<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-	<DateModified val='2000-1-1 23:59:59.000' />
-	<Name>
-			<AUni
-				ws='en'>commonName</AUni>
-	</Name>
-</ownseq>";
-			var ourContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000").Replace("commonName", "ourModifiedName");
+			var dateTimeNowString = DateTimeNowString;
+			var ourContent = CommonOwnSeqAncestor.Replace("2000-1-1 23:59:59.123", "2002-1-1 23:59:59.123").Replace("commonName", "ourModifiedName");
 
-			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(commonAncestor, new XmlDocument());
+			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(CommonOwnSeqAncestor, new XmlDocument());
 			var ancestorModPropNode = ancestorNode.SelectSingleNode("DateModified");
 			var ourNode = XmlUtilities.GetDocumentNodeFromRawXml(ourContent, new XmlDocument());
 			var ourModPropNode = ourNode.SelectSingleNode("DateModified");
 			IPremerger premerger = new PreferMostRecentTimePreMerger();
 			premerger.Premerge(new ListenerForUnitTests(), ref ourModPropNode, null, ancestorModPropNode);
 
-			Assert.AreEqual("2002-1-1 23:59:59.000", ourModPropNode.Attributes["val"].Value);
+			Assert.That(ourModPropNode.Attributes["val"].Value, Is.GreaterThanOrEqualTo(dateTimeNowString));
 		}
 
 		[Test]
 		public void TheirOriginalTimestampRestoredToAncestorValueIfOnlyChangeWasTimestampAndWeDeletedParent()
 		{
-			const string commonAncestor =
-@"<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-	<DateModified val='2000-1-1 23:59:59.000' />
-	<Name>
-			<AUni
-				ws='en'>commonName</AUni>
-	</Name>
-</ownseq>";
-			var theirContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000");
+			var theirContent = CommonOwnSeqAncestor.Replace("2000-1-1 23:59:59.123", "2002-1-1 23:59:59.123");
 
-			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(commonAncestor, new XmlDocument());
+			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(CommonOwnSeqAncestor, new XmlDocument());
 			var ancestorModPropNode = ancestorNode.SelectSingleNode("DateModified");
 			var theirNode = XmlUtilities.GetDocumentNodeFromRawXml(theirContent, new XmlDocument());
 			var theirModPropNode = theirNode.SelectSingleNode("DateModified");
@@ -102,23 +88,16 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 			XmlNode ourNode = null;
 			premerger.Premerge(new ListenerForUnitTests(), ref ourNode, theirModPropNode, ancestorModPropNode);
 
-			Assert.AreEqual("2000-1-1 23:59:59.000", theirModPropNode.Attributes["val"].Value);
+			Assert.AreEqual("2000-1-1 23:59:59.123", theirModPropNode.Attributes["val"].Value);
 		}
 
 		[Test]
-		public void TheirOriginalTimestampKeptIfAnotherChangeWasMadeAndWeDeletedParent()
+		public void TimestampUpdatedIfAnotherChangeWasMadeAndWeDeletedParent()
 		{
-			const string commonAncestor =
-@"<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-	<DateModified val='2000-1-1 23:59:59.000' />
-	<Name>
-			<AUni
-				ws='en'>commonName</AUni>
-	</Name>
-</ownseq>";
-			var theirContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000").Replace("commonName", "theirModifiedName");
+			var dateTimeNowString = DateTimeNowString;
+			var theirContent = CommonOwnSeqAncestor.Replace("2000-1-1 23:59:59.123", "2002-1-1 23:59:59.123").Replace("commonName", "theirModifiedName");
 
-			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(commonAncestor, new XmlDocument());
+			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(CommonOwnSeqAncestor, new XmlDocument());
 			var ancestorModPropNode = ancestorNode.SelectSingleNode("DateModified");
 			var theirNode = XmlUtilities.GetDocumentNodeFromRawXml(theirContent, new XmlDocument());
 			var theirModPropNode = theirNode.SelectSingleNode("DateModified");
@@ -126,21 +105,18 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 			XmlNode ourNode = null;
 			premerger.Premerge(new ListenerForUnitTests(), ref ourNode, theirModPropNode, ancestorModPropNode);
 
-			Assert.AreEqual("2002-1-1 23:59:59.000", theirModPropNode.Attributes["val"].Value);
+			Assert.That(theirModPropNode.Attributes["val"].Value, Is.GreaterThanOrEqualTo(dateTimeNowString));
 		}
 
-		[Test]
-		public void NewerTimestampInOurWins()
-		{
-			const string commonAncestor =
-@"<?xml version='1.0' encoding='utf-8'?>
+		private const string CommonPosAncestor =
+			@"<?xml version='1.0' encoding='utf-8'?>
 <Root>
 <ReversalIndex guid='c1ed46b8-e382-11de-8a39-0800200c9a66'>
 	<PartsOfSpeech>
 		<CmPossibilityList guid ='c1ed46bb-e382-11de-8a39-0800200c9a66' >
 			<Possibilities>
 				<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-					<DateModified val='2000-1-1 23:59:59.000' />
+					DateGoesHere
 					<Name>
 						<AUni
 							ws='en'>commonName</AUni>
@@ -151,88 +127,128 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 	</PartsOfSpeech>
 </ReversalIndex>
 </Root>";
-			var ourContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000").Replace("commonName", "newModifiedName");
-			var theirContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2001-1-1 23:59:59.000").Replace("commonName", "newModifiedName");
 
+		[TestCase("<DateModified val='2000-1-1 23:59:59.123' />", "2002-1-1 23:59:59.123", "2001-1-1 23:59:59.123", "newModifiedName", 2, new[]{ typeof(XmlAttributeBothMadeSameChangeReport), typeof(XmlTextBothMadeSameChangeReport) }, TestName = "Timestamp updated")]
+		[TestCase("", "2002-1-1 23:59:59.123", "2001-1-1 23:59:59.123", "newModifiedName", 2, new[] { typeof(XmlAttributeBothAddedReport), typeof(XmlTextBothMadeSameChangeReport) }, TestName = "Timestamp updated - no ancestor timestamp")]
+		[TestCase("", "2002-1-1 23:59:59.123", "2001-1-1 23:59:59.123", "commonName", 1, new[] { typeof(XmlAttributeBothAddedReport) }, TestName = "DateModified-only change - Timestamp updated")]
+		[TestCase("<DateModified val='2000-1-1 23:59:59.123' />", "2001-1-1 23:59:59.123", "2002-1-1 23:59:59.123", "newModifiedName", 2, new[]{ typeof(XmlAttributeBothMadeSameChangeReport), typeof(XmlTextBothMadeSameChangeReport) })]
+		[TestCase("", "2001-1-1 23:59:59.123", "2002-1-1 23:59:59.123", "commonName", 1, new[] { typeof(XmlAttributeBothAddedReport) })]
+		public void MergeConflict_TimestampUpdated(string ancestorDate, string ourDate, string theirDate, string modification, int expectedChangeCount, Type[] expectedChangeTypes)
+		{
+			var ancestorContent = CommonPosAncestor.Replace("DateGoesHere", ancestorDate);
+			var ourContent = CommonPosAncestor.Replace("DateGoesHere", "<DateModified val='2002-1-1 23:59:59.123' />").Replace("commonName", modification);
+			var theirContent = CommonPosAncestor.Replace("DateGoesHere", "<DateModified val='2001-1-1 23:59:59.123' />").Replace("commonName", modification);
+
+			var dateTimeNow = DateTimeNowString;
+			var results = FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, ourContent,
+				_commonFile, ancestorContent,
+				_theirFile, theirContent,
+				null, null,
+				0, new List<Type>(),
+				expectedChangeCount, new List<Type>(expectedChangeTypes));
+			Assert.That(GetXPathNodeFrom(results, "Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified/@val"),
+				Is.GreaterThan(dateTimeNow));
+		}
+
+		[TestCase("<DateModified val='2000-1-1 23:59:59.123' />", "commonName", 0, new Type[0], TestName = "DateModified-only change sets ancestor timestamp")]
+		public void TimestampOnlyChange_TimestampKept(string ancestorDate, string modification, int expectedChangeCount, Type[] expectedChangeTypes)
+		{
+			var ancestorContent = CommonPosAncestor.Replace("DateGoesHere", ancestorDate);
+			var ourContent = CommonPosAncestor.Replace("DateGoesHere", "<DateModified val='2002-1-1 23:59:59.123' />").Replace("commonName", modification);
+			var theirContent = CommonPosAncestor.Replace("DateGoesHere", "<DateModified val='2001-1-1 23:59:59.123' />").Replace("commonName", modification);
+
+			var results = FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, ourContent,
+				_commonFile, ancestorContent,
+				_theirFile, theirContent,
+				null, null,
+				0, new List<Type>(),
+				expectedChangeCount, new List<Type>(expectedChangeTypes));
+			Assert.That(GetXPathNodeFrom(results, "Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified/@val"),
+				Is.EqualTo("2000-1-1 23:59:59.123"));
+		}
+
+		private static DateTime GetMergedTime(string filePath)
+		{
+			var xmlDocument = new XmlDocument();
+			xmlDocument.Load(filePath);
+			var nodeList = xmlDocument.SelectNodes("Lexicon/LexEntry/DateModified/@val");
+			Assert.That(nodeList.Count, Is.EqualTo(1));
+			DateTime mergedTime;
+			Assert.That(DateTime.TryParse(nodeList[0].Value, out mergedTime), Is.True);
+			return mergedTime;
+		}
+
+		private const string CommonLexEntryAncestor =
+			@"<?xml version='1.0' encoding='utf-8'?>
+<Lexicon>
+	<header>
+		<LexDb guid='lexdb' />
+	</header>
+	<LexEntry guid='c1ed94c5-e382-11de-8a39-0800200c9a66'>
+		<CitationForm>
+			<AUni
+				ws='seh'>ambuka</AUni>
+		</CitationForm>
+		<Comment>
+			<AStr
+				ws='en'>
+				<Run
+					ws='en'>Comment</Run>
+			</AStr>
+		</Comment>
+		<DateCreated
+			val='2005-6-23 16:30:30.433' />
+		<DateModified
+			val='2010-1-1 23:59:59.123' />
+	</LexEntry>
+</Lexicon>";
+
+		[Test]
+		public void TimestampUpdatedIfBothChangedSameRecord()
+		{
+			var ourContent = CommonLexEntryAncestor.Replace("2010-1-1 23:59:59.123", "2011-1-1 23:59:59.123").Replace(">Comment<", ">Our comment<");
+			var theirContent = CommonLexEntryAncestor.Replace("2010-1-1 23:59:59.123", "2012-2-2 23:59:59.123").Replace("ambuka", "their change");
+
+			var utcNow = DateTime.UtcNow;
 			FieldWorksTestServices.DoMerge(
 				FileHandler,
 				_ourFile, ourContent,
-				_commonFile, commonAncestor,
+				_commonFile, CommonLexEntryAncestor,
 				_theirFile, theirContent,
-				new List<string>
-					{
-						@"Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified[@val=""2002-1-1 23:59:59.000""]",
-					}, null,
+				new List<string> {
+					@"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Our comment']",
+					@"Lexicon/LexEntry/CitationForm/AUni[@ws='seh'][text()='their change']" },
+				new List<string> { @"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Comment']" },
 				0, new List<Type>(),
-				2, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport), typeof(XmlTextBothMadeSameChangeReport) });
+				3, new List<Type> { typeof(XmlTextChangedReport), typeof(XmlChangedRecordReport), typeof(XmlAttributeBothMadeSameChangeReport)});
 
-			var ancestorMissingDate = commonAncestor.Replace("<DateModified val='2000-1-1 23:59:59.000' />", "");
-			ourContent = ourContent.Replace("newModifiedName", "commonName");
-			theirContent = theirContent.Replace("newModifiedName", "commonName");
-			FieldWorksTestServices.DoMerge(
-				FileHandler,
-				_ourFile, ourContent,
-				_commonFile, ancestorMissingDate,
-				_theirFile, theirContent,
-				new List<string>
-					{
-						@"Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified[@val=""2002-1-1 23:59:59.000""]",
-					}, null,
-				0, new List<Type>(),
-				1, new List<Type> { typeof(XmlAttributeBothAddedReport) });
+			Assert.That(GetMergedTime(_ourFile.Path), Is.GreaterThan(utcNow));
 		}
 
 		[Test]
-		public void NewerTimestampInTheirsWins()
+		public void TimestampUpdatedIfBothChangedSameFields()
 		{
-			const string commonAncestor =
-@"<?xml version='1.0' encoding='utf-8'?>
-<Root>
-<ReversalIndex guid='c1ed46b8-e382-11de-8a39-0800200c9a66'>
-	<PartsOfSpeech>
-		<CmPossibilityList guid ='c1ed46bb-e382-11de-8a39-0800200c9a66' >
-			<Possibilities>
-				<ownseq class='PartOfSpeech' guid ='c1ed6db0-e382-11de-8a39-0800200c9a66'>
-					<DateModified val='2000-1-1 23:59:59.000' />
-					<Name>
-						<AUni
-							ws='en'>commonName</AUni>
-					</Name>
-				</ownseq>
-			</Possibilities>
-		</CmPossibilityList>
-	</PartsOfSpeech>
-</ReversalIndex>
-</Root>";
-			var ourContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2001-1-1 23:59:59.000").Replace("commonName", "newModifiedName");
-			var theirContent = commonAncestor.Replace("2000-1-1 23:59:59.000", "2002-1-1 23:59:59.000").Replace("commonName", "newModifiedName");
+			var ourContent = CommonLexEntryAncestor.Replace("2010-1-1 23:59:59.123", "2011-1-1 23:59:59.123").Replace(">Comment<", ">Our comment<").Replace("ambuka", "our change");
+			var theirContent = CommonLexEntryAncestor.Replace("2010-1-1 23:59:59.123", "2012-2-2 23:59:59.123").Replace(">Comment<", ">Their comment<").Replace("ambuka", "their change");
 
+			var utcNow = DateTime.UtcNow;
 			FieldWorksTestServices.DoMerge(
 				FileHandler,
 				_ourFile, ourContent,
-				_commonFile, commonAncestor,
+				_commonFile, CommonLexEntryAncestor,
 				_theirFile, theirContent,
-				new List<string>
-					{
-						@"Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified[@val=""2002-1-1 23:59:59.000""]",
-					}, null,
-				0, new List<Type>(),
-				2, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport), typeof(XmlTextBothMadeSameChangeReport) });
+				new List<string> {
+					@"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Our comment']",
+					@"Lexicon/LexEntry/CitationForm/AUni[@ws='seh'][text()='our change']"},
+				new List<string> { @"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Comment']" },
+				2, new List<Type> { typeof(XmlTextBothEditedTextConflict), typeof(BothEditedTheSameAtomicElement) },
+				1, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport)});
 
-			var ancestorMissingDate = commonAncestor.Replace("<DateModified val='2000-1-1 23:59:59.000' />", "");
-			ourContent = ourContent.Replace("newModifiedName", "commonName");
-			theirContent = theirContent.Replace("newModifiedName", "commonName");
-			FieldWorksTestServices.DoMerge(
-				FileHandler,
-				_ourFile, ourContent,
-				_commonFile, ancestorMissingDate,
-				_theirFile, theirContent,
-				new List<string>
-					{
-						@"Root/ReversalIndex/PartsOfSpeech/CmPossibilityList/Possibilities/ownseq/DateModified[@val=""2002-1-1 23:59:59.000""]",
-					}, null,
-				0, new List<Type>(),
-				1, new List<Type> { typeof(XmlAttributeBothAddedReport) });
+			Assert.That(GetMergedTime(_ourFile.Path), Is.GreaterThan(utcNow));
 		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/Linguistics/Lexicon/FieldWorksLexiconTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/Linguistics/Lexicon/FieldWorksLexiconTypeHandlerTests.cs
@@ -210,7 +210,7 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 <LexEntry guid='016f2759-ed12-42a5-abcb-7fe3f53d05b0' />
 </Lexicon>";
 
-			var ourContent = commonAncestor.Replace("True", "False");
+			var ourContent = commonAncestor.Replace("True", "False").Replace("2011-2-2 19:39:28.829", "2013-2-2 19:39:28.829");
 			const string theirContent = commonAncestor;
 
 			var results = FieldWorksTestServices.DoMerge(
@@ -220,7 +220,7 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 				_theirFile, theirContent,
 				null, null,
 				0, new List<Type>(),
-				0, new List<Type>());
+				1, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport)});
 				// Originally this produced one change of type XmlAttributeChangedReport.
 				// This is now suppressed by the special handling of ParseIsCurrent.
 				//1, new List<Type> { typeof(XmlAttributeChangedReport) });
@@ -255,8 +255,8 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 <LexEntry guid='016f2759-ed12-42a5-abcb-7fe3f53d05b0' />
 </Lexicon>";
 
-			var ourContent = commonAncestor.Replace("the first paragraph", "MY first paragraph");
-			var theirContent = commonAncestor.Replace("the first paragraph", "THEIR first paragraph");
+			var ourContent = commonAncestor.Replace("the first paragraph", "MY first paragraph").Replace("2011-2-2 19:39:28.829", "2012-2-2 19:39:28.829");
+			var theirContent = commonAncestor.Replace("the first paragraph", "THEIR first paragraph").Replace("2011-2-2 19:39:28.829", "2013-2-2 19:39:28.829");
 
 			var results = FieldWorksTestServices.DoMerge(
 				FileHandler,
@@ -265,35 +265,37 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 				_theirFile, theirContent,
 				null, null,
 				1, new List<Type> { typeof(BothEditedTheSameAtomicElement) },
-				0, new List<Type>());
+				1, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport) });
 			Assert.IsTrue(results.Contains("MY first paragraph"));
 		}
+
+		private const string baseDocument =
+@"<?xml version='1.0' encoding='utf-8'?>
+<Lexicon>
+	<header>
+		<LexDb guid='06425922-3258-4094-a9ec-3c2fe5b52b39' >
+			<Introduction>
+				<StText guid='45b78bcf-2400-48d5-a9c1-973447d36d4e'>
+					<DateModified val='2011-2-2 19:39:28.829' />
+					<Paragraphs>
+						<ownseq class='StTxtPara' guid='9edbb6e1-2bdd-481c-b84d-26c69f22856c'>
+							<ParseIsCurrent val='False' />
+						</ownseq>
+					</Paragraphs>
+				</StText>
+			</Introduction>
+		</LexDb>
+	</header>
+	<LexEntry guid='016f2759-ed12-42a5-abcb-7fe3f53d05b0' />
+</Lexicon>";
 
 		[Test]
 		public void MergeHasNoReportsForDeepDateModifiedChangesAndKeepsMostRecent()
 		{
-			const string commonAncestor =
-@"<?xml version='1.0' encoding='utf-8'?>
-<Lexicon>
-<header>
-<LexDb guid='06425922-3258-4094-a9ec-3c2fe5b52b39' >
-	  <Introduction>
-		<StText guid='45b78bcf-2400-48d5-a9c1-973447d36d4e'>
-		  <DateModified val='2011-2-2 19:39:28.829' />
-		  <Paragraphs>
-			<ownseq class='StTxtPara' guid='9edbb6e1-2bdd-481c-b84d-26c69f22856c'>
-			  <ParseIsCurrent val='False' />
-			</ownseq>
-		  </Paragraphs>
-		</StText>
-	  </Introduction>
-</LexDb>
-</header>
-<LexEntry guid='016f2759-ed12-42a5-abcb-7fe3f53d05b0' />
-</Lexicon>";
-
+			const string commonAncestor = baseDocument;
 			var ourContent = commonAncestor.Replace("2011-2-2 19:39:28.829", "2012-2-2 19:39:28.829").Replace("False", "True");
 			var theirContent = commonAncestor.Replace("2011-2-2 19:39:28.829", "2013-2-2 19:39:28.829").Replace("False", "True");
+			var dateTimeNow = DateTimeNowString;
 
 			var results = FieldWorksTestServices.DoMerge(
 				FileHandler,
@@ -303,37 +305,19 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 				null, null,
 				0, new List<Type>(),
 				2, new List<Type> { typeof(XmlAttributeBothMadeSameChangeReport), typeof(XmlAttributeBothMadeSameChangeReport) });
-			Assert.IsTrue(results.Contains("2013-2-2 19:39:28.829"));
+			Assert.That(GetXPathNodeFrom(results, "Lexicon/header/LexDb/Introduction/StText/DateModified/@val"), Is.GreaterThan(dateTimeNow));
 		}
 
 		[Test]
 		public void SampleMergeWithConflicts()
 		{
-			const string commonAncestor =
-@"<?xml version='1.0' encoding='utf-8'?>
-<Lexicon>
-<header>
-<LexDb guid='06425922-3258-4094-a9ec-3c2fe5b52b39' >
-	  <Introduction>
-		<StText guid='45b78bcf-2400-48d5-a9c1-973447d36d4e'>
-		  <DateModified val='2011-2-2 19:39:28.829' />
-		  <Paragraphs>
-			<ownseq class='StTxtPara' guid='9edbb6e1-2bdd-481c-b84d-26c69f22856c'>
-			  <ParseIsCurrent val='False' />
-			</ownseq>
-		  </Paragraphs>
-		</StText>
-	  </Introduction>
-	  <Name>
-		<AUni ws='en'>Original Dictionary</AUni>
-	  </Name>
-</LexDb>
-</header>
-<LexEntry guid='016f2759-ed12-42a5-abcb-7fe3f53d05b0' />
-</Lexicon>";
+			var commonAncestor = baseDocument.Replace("</Introduction>", @"</Introduction>
+				<Name>
+					<AUni ws='en'>Original Dictionary</AUni>
+				</Name>");
 
-			var ourContent = commonAncestor.Replace("Original Dictionary", "My Dictionary");
-			var theirContent = commonAncestor.Replace("Original Dictionary", "Their Dictionary");
+			var ourContent = commonAncestor.Replace("Original Dictionary", "My Dictionary").Replace("2011-2-2 19:39:28.829", "2012-2-2 19:39:28.829");
+			var theirContent = commonAncestor.Replace("Original Dictionary", "Their Dictionary").Replace("2011-2-2 19:39:28.829", "2013-2-2 19:39:28.829");
 
 			var results = FieldWorksTestServices.DoMerge(
 				FileHandler,
@@ -1180,6 +1164,45 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Linguistics.Lexicon
 				new List<string> { @"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='TheirAddition']" },
 				1, new List<Type> { typeof(BothEditedTheSameAtomicElement) },
 				0, new List<Type>());
+		}
+
+		[Test]
+		public void BothEditedDifferentParts_MergedWithoutConflict()
+		{
+			const string commonAncestor =
+				@"<?xml version='1.0' encoding='utf-8'?>
+<Lexicon>
+	<header>
+		<LexDb guid='lexdb' />
+	</header>
+	<LexEntry guid='c1ed94c5-e382-11de-8a39-0800200c9a66'>
+		<CitationForm>
+			<AUni
+				ws='seh'>ambuka</AUni>
+		</CitationForm>
+		<Comment>
+			<AStr
+				ws='en'>
+				<Run
+					ws='en'>Comment</Run>
+			</AStr>
+		</Comment>
+	</LexEntry>
+</Lexicon>";
+			var ourContent = commonAncestor.Replace(">Comment<", ">Our comment<");
+			var theirContent = commonAncestor.Replace("ambuka", "their change");
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, ourContent,
+				_commonFile, commonAncestor,
+				_theirFile, theirContent,
+				new List<string> {
+					@"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Our comment']",
+					@"Lexicon/LexEntry/CitationForm/AUni[@ws='seh'][text()='their change']" },
+				new List<string> { @"Lexicon/LexEntry/Comment/AStr[@ws='en']/Run[text()='Comment']" },
+				0, new List<Type>(),
+				2, new List<Type> { typeof(XmlTextChangedReport), typeof(XmlChangedRecordReport)});
 		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/PreferMostRecentTimePreMergerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/PreferMostRecentTimePreMergerTests.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) 2017 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Xml;
+using LibFLExBridgeChorusPlugin.Handling;
+using NUnit.Framework;
+using Chorus.merge.xml.generic;
+using System;
+
+namespace LibFLExBridgeChorusPluginTests.Handling
+{
+	[TestFixture]
+	public class PreferMostRecentTimePreMergerTests
+	{
+		private const string CommonAncestor = @"
+<root>
+	<DateModified val='2010-1-2 3:4:5.678'/>
+	<SummaryDefinition>
+		<AStr ws='en'><Run ws='en'>English summary</Run></AStr>
+	</SummaryDefinition>
+</root>";
+
+		private readonly IPremerger _preMerger = new PreferMostRecentTimePreMerger();
+		private string _dateTimeNow;
+		private int _count;
+
+		private XmlNode CreateNode(string xml)
+		{
+			xml = xml.Replace("2010-1-2 3:4:5.678", string.Format("2010-1-{0} 3:4:5.678", _count++));
+			var doc = new XmlDocument();
+			doc.LoadXml(xml);
+			return doc.SelectSingleNode("/root/DateModified");
+		}
+
+		private static string GetDateTimeValue(XmlNode xml)
+		{
+			return xml.SelectSingleNode("/root/DateModified/@val").Value;
+		}
+
+		[SetUp]
+		public void SetUp()
+		{
+			_dateTimeNow = BaseFieldWorksTypeHandlerTests.DateTimeNowString;
+			_count = 3;
+		}
+
+		[Test]
+		public void PreMerge_NoAncestorAddedSame_UpdatesTimestamp()
+		{
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, null);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_NoAncestorAddedConflictingChangeOnSameChild_UpdatesTimestamp()
+		{
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='1' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, null);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_NoAncestorAddedDifferentNodes_UpdatesTimestamp()
+		{
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<LiteralMeaning>
+		<AStr ws='en'><Run ws='en'>English meaning</Run></AStr>
+	</LiteralMeaning>
+</root>"));
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='1' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, null);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_WithAncestorWeAdded_UpdatesTimestamp()
+		{
+			var ancestor = CreateNode(CommonAncestor);
+			var theirs = CreateNode(CommonAncestor);
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, ancestor);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_WithAncestorTheyAdded_UpdatesTimestamp()
+		{
+			var ancestor = CreateNode(CommonAncestor);
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+			var ours = CreateNode(CommonAncestor);
+
+			_preMerger.Premerge(null, ref ours, theirs, ancestor);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_WithAncestorAddedSame_UpdatesTimestamp()
+		{
+			var ancestor = CreateNode(CommonAncestor);
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, ancestor);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+
+		[Test]
+		public void PreMerge_WithAncestorOnlyTimestampChange_KeepsTimestamp()
+		{
+			var ancestor = CreateNode(CommonAncestor);
+			var theirs = CreateNode(CommonAncestor);
+			var ours = CreateNode(CommonAncestor);
+
+			_preMerger.Premerge(null, ref ours, theirs, ancestor);
+			Assert.That(GetDateTimeValue(ours), Is.EqualTo("2010-1-3 3:4:5.678"));
+		}
+
+				[Test]
+		public void PreMerge_WithAncestorAddedConflictingChange_UpdatesTimestamp()
+		{
+			var ancestor = CreateNode(CommonAncestor);
+			var theirs = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='0' />
+</root>"));
+			var ours = CreateNode(CommonAncestor.Replace("</root>", @"
+	<HomographNumber val='1' />
+</root>"));
+
+			_preMerger.Premerge(null, ref ours, theirs, ancestor);
+			Assert.That(GetDateTimeValue(ours), Is.GreaterThanOrEqualTo(_dateTimeNow));
+		}
+	}
+}

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Infrastructure\FLExProjectUnifierTests.cs" />
     <Compile Include="Infrastructure\LibFLExBridgeUtilitiesTests.cs" />
     <Compile Include="Integration\UpdateMetaDataCacheTests.cs" />
+    <Compile Include="Handling\PreferMostRecentTimePreMergerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibFLExBridge-ChorusPlugin\LibFLExBridge-ChorusPlugin.csproj">


### PR DESCRIPTION
This fixes a problem when doing S/R in LanguageForge. LF relies on the DateModified time stamp to know which entries it needs to process. If an entry got modified in FLEx and the same entry but
different field got modified in LF, the S/R merged the changes but set the DateModified field to the newer date (which was from LF). This caused LF not to re-process the entry because it already
processed the entry with that time stamp. This caused the modified data from FLEx to not show up in LF (https://trello.com/c/UoyXj4jP).

This change fixes this problem by setting DateModified to the current time in case of a merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/137)
<!-- Reviewable:end -->
