### PR TITLE
Don't suppress Mercurial readiness error message

### DIFF
--- a/src/LfMergeBridge/LfMergeBridge.cs
+++ b/src/LfMergeBridge/LfMergeBridge.cs
@@ -41,7 +41,7 @@ namespace LfMergeBridge
 			var readinessMessage = HgRepository.GetEnvironmentReadinessMessage("en");
 			if (!string.IsNullOrEmpty(readinessMessage))
 			{
-				somethingForClient = @"Mercurial is not set up properly";
+				somethingForClient = @"Mercurial is not set up properly: " + readinessMessage;
 				return false;
 			}
 


### PR DESCRIPTION
If Mercurial is not set up properly, pass Mercurial's error message on to the client so the client can figure out what to do about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/138)
<!-- Reviewable:end -->
