### PR TITLE
Fix "unknown action type" error message

### DIFF
--- a/src/LfMergeBridge/LfMergeBridge.cs
+++ b/src/LfMergeBridge/LfMergeBridge.cs
@@ -56,7 +56,7 @@ namespace LfMergeBridge
 					var currentHandler = handlerRepository.GetHandler(StringToActionTypeConverter.GetActionType(actionType));
 					if (currentHandler == null)
 					{
-						somethingForClient = string.Format(@"Requested action type '{0}' is not supported in Language Forge Merge Bridge.", options[actionType]);
+						somethingForClient = string.Format(@"Requested action type '{0}' is not supported in Language Forge Merge Bridge.", actionType);
 						return false;
 					}
 					somethingForClient = string.Empty;


### PR DESCRIPTION
The `actionType` string isn't a key into the `options` dictionary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/139)
<!-- Reviewable:end -->
