### PR TITLE
Send/Receive Chorus Notes with LF comments

### DIFF
--- a/src/LfMergeBridge/LanguageForgeGetChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeGetChorusNotesActionHandler.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) 2010-2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT) (See: license.rtf file)
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Json;
+using Newtonsoft.Json;
+using System.Text;
+using Chorus;
+using Chorus.merge;
+using Chorus.notes;
+using Chorus.Utilities;
+using TriboroughBridge_ChorusPlugin;
+using TriboroughBridge_ChorusPlugin.Infrastructure;
+using LibTriboroughBridgeChorusPlugin;
+using LibTriboroughBridgeChorusPlugin.Infrastructure;
+using LibFLExBridgeChorusPlugin.Infrastructure;
+using Palaso.Progress;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	/// <summary>
+	/// This IBridgeActionTypeHandler implementation handles everything needed for viewing the notes of a Flex repo.
+	/// </summary>
+	[Export(typeof (IBridgeActionTypeHandler))]
+	internal sealed class LanguageForgeGetChorusNotesActionHandler : IBridgeActionTypeHandler
+	{
+		public const string mainNotesFilenameStub = "Lexicon.fwstub";
+		public const string chorusNotesExt = ".ChorusNotes";
+		public const string mainNotesFilename = mainNotesFilenameStub + chorusNotesExt;
+		public const string zeroGuidStr = "00000000-0000-0000-0000-000000000000";
+		public const string genericAuthorName = "Language Forge";
+		internal string ProjectName { get; set; }
+		internal string ProjectDir { get; set; }
+
+		#region IBridgeActionTypeHandler impl
+
+		/// <summary>
+		/// Start doing whatever is needed for the supported type of action.
+		/// </summary>
+		void IBridgeActionTypeHandler.StartWorking(IProgress progress, Dictionary<string, string> options, ref string somethingForClient)
+		{
+			var pOption = options["-p"];
+			ProjectName = Path.GetFileNameWithoutExtension(pOption);
+			ProjectDir = Path.GetDirectoryName(pOption);
+
+			string inputFilename = options[LfMergeBridge.LfMergeBridgeUtilities.serializedCommentsFromLfMerge];
+			List<SerializableLfComment> commentsFromLF = LfMergeBridge.LfMergeBridgeUtilities.DecodeJsonFile<List<SerializableLfComment>>(inputFilename);
+			var knownCommentGuids = new HashSet<string>(commentsFromLF.Where(comment => comment.Guid != null).Select(comment => comment.Guid));
+			var knownReplyGuids = new HashSet<string>(commentsFromLF.Where(comment => comment.Replies != null).SelectMany(comment => comment.Replies.Where(reply => reply.Guid != null).Select(reply => reply.Guid)));
+
+			var lfComments = new List<SerializableLfComment>();
+			var lfReplies = new List<Tuple<string, List<SerializableLfCommentReply>>>();
+			// TODO: See if we want to suppress progress messages here by using a NullProgress instance instead of the IProgress instance we were given...
+			foreach (Annotation ann in GetAllAnnotations(progress, ProjectDir))
+			{
+				if (knownCommentGuids.Contains(ann.Guid))
+				{
+					// Known comment; only serialize new replies
+					List<SerializableLfCommentReply> repliesNotYetInLf =
+						ann
+							.Messages
+							.Skip(1)  // First message translates to the LF *comment*, while subsequent messages are *replies* in LF
+							.Where(m => ! String.IsNullOrWhiteSpace(m.Text))
+							.Where(m => ! knownReplyGuids.Contains(m.Guid))
+							.Select(ReplyFromChorusMsg)
+							.ToList();
+					if (repliesNotYetInLf.Count > 0)
+					{
+						lfReplies.Add(new Tuple<string, List<SerializableLfCommentReply>>(ann.Guid, repliesNotYetInLf));
+					}
+				}
+				else
+				{
+					// New comment: serialize everything
+					var msg = ann.Messages.FirstOrDefault();
+					var lfComment = new SerializableLfComment {
+						Guid = ann.Guid,
+						// AuthorNameAlternate = msg?.Author ?? string.Empty,  // C# 6 syntax would be simpler if we could count on a C# 6 compiler everywhere
+						AuthorNameAlternate = (msg == null) ? string.Empty : msg.Author,
+						DateCreated = ann.Date,
+						DateModified = ann.Date,
+						// Content = msg?.Text ?? string.Empty,  // C# 6 syntax would be simpler if we could count on a C# 6 compiler everywhere
+						Content = (msg == null) ? string.Empty : msg.Text,
+						Status = ChorusStatusToLfStatus(ann.Status),
+						Replies = new List<SerializableLfCommentReply>(ann.Messages.Skip(1).Where(m => ! String.IsNullOrWhiteSpace(m.Text)).Select(ReplyFromChorusMsg)),
+						IsDeleted = false
+					};
+					lfComment.Regarding = new SerializableLfCommentRegarding {
+						TargetGuid = ExtractGuidFromChorusRef(ann.RefStillEscaped),
+						// Word and Meaning will be set in LfMerge, but set them to something vaguely sensible here as a fallback
+						Word = ann.LabelOfThingAnnotated,
+						Meaning = string.Empty
+					};
+					lfComments.Add(lfComment);
+				}
+			}
+			var serializedComments = new StringBuilder("New comments not yet in LF: ");
+			serializedComments.Append(JsonConvert.SerializeObject(lfComments));
+			LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, serializedComments.ToString());
+
+			var serializedReplies = new StringBuilder("New replies on comments already in LF: ");
+			serializedReplies.Append(JsonConvert.SerializeObject(lfReplies));
+			LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, serializedReplies.ToString());
+		}
+
+		private SerializableLfCommentReply ReplyFromChorusMsg(Message msg)
+		{
+			var reply = new SerializableLfCommentReply();
+			reply.Guid = msg.Guid;
+			reply.AuthorNameAlternate = msg.Author;
+			if (reply.AuthorInfo == null)
+				reply.AuthorInfo = new SerializableLfAuthorInfo();
+			reply.AuthorInfo.CreatedDate = msg.Date;
+			reply.AuthorInfo.ModifiedDate = msg.Date;
+			reply.Content = msg.Text;
+			reply.IsDeleted = false;
+			reply.UniqId = null; // This will be set in LfMerge.
+			return reply;
+		}
+
+		private string ExtractGuidFromChorusRef(string refStillEscaped)
+		{
+			var repos = AnnotationRepository.CreateRepositoriesFromFolder(ProjectDir, new NullProgress());
+			var repo = repos.First();
+			// TODO: Delete the lines above
+			return UrlHelper.GetValueFromQueryStringOfRef(refStillEscaped, "guid", string.Empty);
+		}
+
+		private string ChorusStatusToLfStatus(string status)
+		{
+			if (status == Chorus.notes.Annotation.Closed)
+			{
+				return SerializableLfComment.Resolved;
+			}
+			else
+			{
+				return SerializableLfComment.Open; // LfMerge will look at this and see if the Mongo DB contained "Todo".
+			}
+		}
+
+		IEnumerable<Annotation> GetAllAnnotations(IProgress progress, string projectDir)
+		{
+			return from repo in AnnotationRepository.CreateRepositoriesFromFolder(projectDir, progress)
+				from ann in repo.GetAllAnnotations()
+				select ann;
+		}
+
+		/// <summary>
+		/// Get the type of action supported by the handler.
+		/// </summary>
+		ActionType IBridgeActionTypeHandler.SupportedActionType
+		{
+			get { return ActionType.LanguageForgeGetChorusNotes; }
+		}
+
+		#endregion IBridgeActionTypeHandler impl
+	}
+}

--- a/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
@@ -85,8 +85,16 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 					}
 					else
 					{
+						// We don't have a C# 6 compiler in our build infrastructure, so we have to do this the hard(er) way.
+						string guidForLog = lfAnnotation == null ? "(no guid)" :
+							lfAnnotation.Guid == null ? "(no guid)" :
+							lfAnnotation.Guid.ToString();
+						string contentForLog = lfAnnotation == null ? "(no content)" : lfAnnotation.Content ?? "(no content)";
 						LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping deleted annotation {0} containing content \"{1}\"",
-							lfAnnotation?.Guid ?? "(no guid)", lfAnnotation?.Content ?? "(no content)"));
+							guidForLog, contentForLog));
+						// The easy way would have been able to skip creating guidForLog and contentForLog; that would have looked like:
+						// LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping deleted annotation {0} containing content \"{1}\"",
+						// 	lfAnnotation?.Guid ?? "(no guid)", lfAnnotation?.Content ?? "(no content)"));
 					}
 					continue;
 				}

--- a/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) 2010-2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT) (See: license.rtf file)
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Json;
+using Newtonsoft.Json;
+using System.Text;
+using Chorus;
+using Chorus.merge;
+using Chorus.notes;
+using TriboroughBridge_ChorusPlugin;
+using TriboroughBridge_ChorusPlugin.Infrastructure;
+using LibTriboroughBridgeChorusPlugin;
+using LibTriboroughBridgeChorusPlugin.Infrastructure;
+using LibFLExBridgeChorusPlugin.Infrastructure;
+using Palaso.Progress;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	/// <summary>
+	/// This IBridgeActionTypeHandler implementation handles writing new notes (which probably came from comments on the Language Forge site) into the ChorusNotes system.
+	/// </summary>
+	[Export(typeof (IBridgeActionTypeHandler))]
+	internal sealed class LanguageForgeWriteToChorusNotesActionHandler : IBridgeActionTypeHandler
+	{
+		public const string mainNotesFilenameStub = "Lexicon.fwstub";
+		public const string chorusNotesExt = ".ChorusNotes";
+		public const string mainNotesFilename = mainNotesFilenameStub + chorusNotesExt;
+		public const string zeroGuidStr = "00000000-0000-0000-0000-000000000000";
+		public const string genericAuthorName = "Language Forge";
+
+		internal string ProjectName { get; set; }
+		internal string ProjectDir { get; set; }
+
+		private IProgress Progress { get; set; }
+
+		#region IBridgeActionTypeHandler impl
+
+		/// <summary>
+		/// Start doing whatever is needed for the supported type of action.
+		/// </summary>
+		void IBridgeActionTypeHandler.StartWorking(IProgress progress, Dictionary<string, string> options, ref string somethingForClient)
+		{
+			var pOption = options["-p"];
+			ProjectName = Path.GetFileNameWithoutExtension(pOption);
+			ProjectDir = Path.GetDirectoryName(pOption);
+			Progress = progress;
+
+			string inputFilename = options[LfMergeBridge.LfMergeBridgeUtilities.serializedCommentsFromLfMerge];
+			string data = File.ReadAllText(inputFilename);
+
+			List<KeyValuePair<string, SerializableLfComment>> commentsFromLF = LfMergeBridge.LfMergeBridgeUtilities.DecodeJsonFile<List<KeyValuePair<string, SerializableLfComment>>>(inputFilename);
+			AnnotationRepository[] annRepos = GetAnnotationRepositories(progress);
+			AnnotationRepository primaryRepo = annRepos[0];
+
+			// The LINQ-based approach in the following line does NOT work, because there can be duplicate keys for some reason.
+			// Dictionary<string, Annotation> chorusAnnotationsByGuid = annRepos.SelectMany(repo => repo.GetAllAnnotations()).ToDictionary(ann => ann.Guid, ann => ann);
+			// Instead we have to do it by hand:
+			var chorusAnnotationsByGuid = new Dictionary<string, Annotation>();
+			foreach (Annotation ann in annRepos.SelectMany(repo => repo.GetAllAnnotations()))
+			{
+				chorusAnnotationsByGuid[ann.Guid] = ann;
+			}
+
+			// We'll keep track of any comment IDs and reply IDs from LF that didn't have GUIDs when they were handed to us, and make sure
+			// that LfMerge can assign the right GUIDs to the right comment and/or reply IDs.
+			// Two dictionaries are needed, because comment IDs are Mongo ObjectId instances, whereas reply IDs are strings coming from PHP's so-called "uniqid" function.
+			var commentIdsThatNeedGuids = new Dictionary<string,string>();
+			var replyIdsThatNeedGuids = new Dictionary<string,string>();
+
+			foreach (KeyValuePair<string, SerializableLfComment> kvp in commentsFromLF)
+			{
+				string lfAnnotationObjectId = kvp.Key;
+				SerializableLfComment lfAnnotation = kvp.Value;
+				if (lfAnnotation == null || lfAnnotation.IsDeleted)
+				{
+					if (lfAnnotation == null)
+					{
+						LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping null annotation with MongoId {0}",
+							lfAnnotationObjectId ?? "(null ObjectId)"));
+					}
+					else
+					{
+						LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping deleted annotation {0} containing content \"{1}\"",
+							lfAnnotation?.Guid ?? "(no guid)", lfAnnotation?.Content ?? "(no content)"));
+					}
+					continue;
+				}
+				// TODO: Once we're compiling with C# 6, use the ?. syntax below instead of the more lengthy (== null) syntax that we're currently using.
+				// string ownerGuid = lfAnnotation.Regarding?.TargetGuid ?? string.Empty;
+				// string ownerShortName = lfAnnotation.Regarding?.Word ?? "???";  // Match FLEx's behavior when short name can't be determined
+				string ownerGuid = (lfAnnotation.Regarding == null) ? string.Empty : lfAnnotation.Regarding.TargetGuid;
+				string ownerShortName = (lfAnnotation.Regarding == null) ? "???" : lfAnnotation.Regarding.Word;  // Match FLEx's behavior when short name can't be determined
+
+				Annotation chorusAnnotation;
+				if (lfAnnotation.Guid != null && chorusAnnotationsByGuid.TryGetValue(lfAnnotation.Guid, out chorusAnnotation) && chorusAnnotation != null)
+				{
+					SetChorusAnnotationMessagesFromLfReplies(chorusAnnotation, lfAnnotation, lfAnnotationObjectId, replyIdsThatNeedGuids, commentIdsThatNeedGuids);
+				}
+				else
+				{
+					Annotation newAnnotation = CreateAnnotation(lfAnnotation.Content, lfAnnotation.Guid, lfAnnotation.AuthorNameAlternate, lfAnnotation.Status, ownerGuid, ownerShortName);
+					SetChorusAnnotationMessagesFromLfReplies(newAnnotation, lfAnnotation, lfAnnotationObjectId, replyIdsThatNeedGuids, commentIdsThatNeedGuids);
+					primaryRepo.AddAnnotation(newAnnotation);
+				}
+			}
+
+			LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("New comment ID->Guid mappings: {0}",
+				String.Join(";", commentIdsThatNeedGuids.Select(kv => String.Format("{0}={1}", kv.Key, kv.Value)))));
+			LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("New reply ID->Guid mappings: {0}",
+				String.Join(";", replyIdsThatNeedGuids.Select(kv => String.Format("{0}={1}", kv.Key, kv.Value)))));
+
+			SaveReposIfNeeded(annRepos, progress);
+		}
+
+		private void SaveReposIfNeeded(IEnumerable<AnnotationRepository> repos, IProgress progress)
+		{
+			foreach (var repo in repos)
+			{
+				repo.SaveNowIfNeeded(progress);
+			}
+		}
+
+		private string LfStatusToChorusStatus(string lfStatus)
+		{
+			if (lfStatus == SerializableLfComment.Resolved)
+			{
+				return Chorus.notes.Annotation.Closed;
+			}
+			else
+			{
+				return Chorus.notes.Annotation.Open;
+			}
+		}
+
+		private void SetChorusAnnotationMessagesFromLfReplies(Annotation chorusAnnotation, SerializableLfComment annotationInfo, string annotationObjectId, Dictionary<string,string> uniqIdsThatNeedGuids, Dictionary<string,string> commentIdsThatNeedGuids)
+		{
+			// Any LF comments that do NOT yet have GUIDs need them set from the corresponding Chorus annotation
+			if (String.IsNullOrEmpty(annotationInfo.Guid) && !String.IsNullOrEmpty(annotationObjectId))
+			{
+				commentIdsThatNeedGuids[annotationObjectId] = chorusAnnotation.Guid;
+			}
+
+			if (annotationInfo.Replies == null || annotationInfo.Replies.Count <= 0)
+			{
+				return;  // Nothing, or nothing else, to do!
+			}
+
+			var chorusMsgGuids = new HashSet<string>(chorusAnnotation.Messages.Select(msg => msg.Guid).Where(s => ! string.IsNullOrEmpty(s) && s != zeroGuidStr));
+			string statusToSet = LfStatusToChorusStatus(annotationInfo.Status);
+			// If we're in this function, the Chorus annotation already contains the text of the LF annotation's comment,
+			// so the only thing we need to go through are the replies.
+			foreach (SerializableLfCommentReply reply in annotationInfo.Replies)
+			{
+				if (reply.IsDeleted || chorusMsgGuids.Contains(reply.Guid))
+				{
+					continue;
+				}
+				Message newChorusMsg = chorusAnnotation.AddMessage(reply.AuthorNameAlternate, statusToSet, reply.Content);
+				if ((string.IsNullOrEmpty(reply.Guid) || reply.Guid == zeroGuidStr) && ! string.IsNullOrEmpty(reply.UniqId))
+				{
+					uniqIdsThatNeedGuids[reply.UniqId] = newChorusMsg.Guid;
+				}
+			}
+			// Since LF allows changing a comment's status without adding any replies, it's possible we haven't updated the Chorus status yet at this point.
+			// But first, check for a special case. Oten, the Chorus annotation's status will be blank, which corresponds to "open" in LfMerge. We don't want
+			// to add a blank message just to change the Chorus status from "" (empty string) to "open", so we need to detect this situation specially.
+			if (String.IsNullOrEmpty(chorusAnnotation.Status) && statusToSet == Chorus.notes.Annotation.Open)
+			{
+				// No need for new status here
+			}
+			else if (statusToSet != chorusAnnotation.Status)
+			{
+				// LF doesn't keep track of who clicked on the "Resolved" or "Todo" buttons, so we have to be vague about authorship
+				chorusAnnotation.SetStatus(genericAuthorName, statusToSet);
+			}
+		}
+
+		private AnnotationRepository[] GetAnnotationRepositories(IProgress progress)
+		{
+			AnnotationRepository[] projectRepos = AnnotationRepository.CreateRepositoriesFromFolder(ProjectDir, progress).ToArray();
+			// Order of these repos doesn't matter, *except* that we want the "main" repo to be first in the array
+			if (projectRepos.Length <= 0)
+			{
+				var primaryRepo = MakePrimaryAnnotationRepository();
+				return new AnnotationRepository[] { primaryRepo };
+			}
+			else
+			{
+				int idx = Array.FindIndex(projectRepos, repo => repo.AnnotationFilePath.Contains(mainNotesFilename));
+				if (idx < 0)
+				{
+					var primaryRepo = MakePrimaryAnnotationRepository();
+					var result = new AnnotationRepository[projectRepos.Length + 1];
+					result[0] = primaryRepo;
+					Array.Copy(projectRepos, 0, result, 1, projectRepos.Length);
+					return result;
+				}
+				else if (idx == 0)
+				{
+					return projectRepos;
+				}
+				else
+				{
+					// Since order of the other repos doesn't matter, just swap the primary into first position
+					var primaryRepo = projectRepos[idx];
+					projectRepos[idx] = projectRepos[0];
+					projectRepos[0] = primaryRepo;
+					return projectRepos;
+				}
+			}
+		}
+
+		private AnnotationRepository MakePrimaryAnnotationRepository()
+		{
+			string fname = Path.Combine(ProjectDir, mainNotesFilenameStub);
+			EnsureFileExists(fname, "This is a stub file to provide an attachment point for " + mainNotesFilename);
+			return AnnotationRepository.FromFile("id", fname, new NullProgress());
+		}
+
+		private void EnsureFileExists(string filename, string contentToCreateFileWith)
+		{
+			if (!File.Exists(filename))
+			{
+				using (var writer = new StreamWriter(filename, false, Encoding.UTF8))
+				{
+					writer.WriteLine(contentToCreateFileWith);
+				}
+			}
+		}
+
+		private Annotation CreateAnnotation(string content, string guidStr, string author, string status, string ownerGuidStr, string ownerShortName)
+		{
+			Guid guid;
+			if (Guid.TryParse(guidStr, out guid))
+			{
+				if (guid == Guid.Empty)
+				{
+					guid = Guid.NewGuid();
+				}
+			}
+			else
+			{
+				guid = Guid.NewGuid();
+			}
+			if (string.IsNullOrEmpty(author))
+			{
+				author = genericAuthorName;
+			}
+			var result = new Annotation("note", MakeFlexRefURL(ownerGuidStr, ownerShortName), guid, "ignored");
+			result.AddMessage(author, LfStatusToChorusStatus(status), content);
+			return result;
+		}
+
+		private static string MakeFlexRefURL(string guidStr, string shortName)
+		{
+			return string.Format("silfw://localhost/link?app=flex&database=current&server=&tool=default&guid={0}&tag=&id={0}&label={1}", guidStr, shortName);
+		}
+
+		/// <summary>
+		/// Get the type of action supported by the handler.
+		/// </summary>
+		ActionType IBridgeActionTypeHandler.SupportedActionType
+		{
+			get { return ActionType.LanguageForgeWriteToChorusNotes; }
+		}
+
+		#endregion IBridgeActionTypeHandler impl
+	}
+}

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -48,7 +48,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <Reference Include="LibChorus">
@@ -83,19 +89,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="LanguageForgeCommitAuxiliaryActionHandler.cs" />
-    <Compile Include="LanguageForgeMakeCloneActionHandler.cs" />
-    <Compile Include="LanguageForgeSendReceiveActionHandler.cs" />
-    <Compile Include="LanguageForgeUpdateToLongHashActionHandler.cs" />
-    <Compile Include="LfMergeBridgeUtilities.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LfMergeBridge.cs" />
-    <Compile Include="..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
     <ProjectReference Include="..\LibFLExBridge-ChorusPlugin\LibFLExBridge-ChorusPlugin.csproj">
       <Project>{67DCA42D-0666-4BDB-BF7B-F3FAB2A6EFED}</Project>
       <Name>LibFLExBridge-ChorusPlugin</Name>
@@ -104,5 +97,28 @@
       <Project>{8E6DD218-7BA1-4119-82D2-535C05A0923C}</Project>
       <Name>LibTriboroughBridge-ChorusPlugin</Name>
     </ProjectReference>
+    <ProjectReference Include="..\TriboroughBridge-ChorusPlugin\TriboroughBridge-ChorusPlugin.csproj">
+      <Project>{8F9F6C42-2BB6-49E1-831D-7414CA411845}</Project>
+      <Name>TriboroughBridge-ChorusPlugin</Name>
+    </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SerializableLfAuthorInfo.cs" />
+    <Compile Include="SerializableLfComment.cs" />
+    <Compile Include="SerializableLfCommentRegarding.cs" />
+    <Compile Include="SerializableLfCommentReply.cs" />
+    <Compile Include="LanguageForgeCommitAuxiliaryActionHandler.cs" />
+    <Compile Include="LanguageForgeGetChorusNotesActionHandler.cs" />
+    <Compile Include="LanguageForgeMakeCloneActionHandler.cs" />
+    <Compile Include="LanguageForgeSendReceiveActionHandler.cs" />
+    <Compile Include="LanguageForgeUpdateToLongHashActionHandler.cs" />
+    <Compile Include="LanguageForgeWriteToChorusNotesActionHandler.cs" />
+    <Compile Include="LfMergeBridgeUtilities.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="LfMergeBridge.cs" />
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/LfMergeBridge/LfMergeBridgeUtilities.cs
+++ b/src/LfMergeBridge/LfMergeBridgeUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Chorus.VcsDrivers.Mercurial;
+using Newtonsoft.Json;
 using Palaso.Progress;
 
 namespace LfMergeBridge
@@ -22,6 +23,7 @@ namespace LfMergeBridge
 		internal const string deleteRepoIfNoSuchBranch = "deleteRepoIfNoSuchBranch";
 		internal const string onlyRepairRepo = "onlyRepairRepo";
 		internal const string commitMessage = "commitMessage";
+		internal const string serializedCommentsFromLfMerge = "serializedCommentsFromLfMerge";
 
 		internal const string failure = "failure";
 		internal const string warning = "warning";
@@ -86,6 +88,12 @@ namespace LfMergeBridge
 				highestLocalRevisionNumber = currentLocalRevisionNumber;
 			}
 			return highestRevision;
+		}
+
+		public static T DecodeJsonFile<T>(string inputFilename)
+		{
+			string data = System.IO.File.ReadAllText(inputFilename, System.Text.Encoding.UTF8);
+			return JsonConvert.DeserializeObject<T>(data);
 		}
 	}
 }

--- a/src/LfMergeBridge/SerializableLfAuthorInfo.cs
+++ b/src/LfMergeBridge/SerializableLfAuthorInfo.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	[DataContract]
+	public class SerializableLfAuthorInfo
+	{
+		[DataMember] public DateTime ModifiedDate { get; set; }
+		[DataMember] public DateTime CreatedDate { get; set; }
+	}
+}

--- a/src/LfMergeBridge/SerializableLfComment.cs
+++ b/src/LfMergeBridge/SerializableLfComment.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	[DataContract]
+	public class SerializableLfComment
+	{
+ 		public static readonly string Open = "open";
+		public static readonly string Resolved = "resolved";
+ 		public static readonly string Todo = "todo";
+		[DataMember] public string Guid { get; set; }
+		[DataMember] public string AuthorNameAlternate { get; set; }
+		[DataMember] public SerializableLfCommentRegarding Regarding { get; set; }
+		[DataMember] public DateTime DateCreated { get; set; }
+		[DataMember] public DateTime DateModified { get; set; }
+		[DataMember] public string Content { get; set; }
+		[DataMember] public string Status { get; set; }
+		[DataMember] public List<SerializableLfCommentReply> Replies { get; set; }
+		[DataMember] public bool IsDeleted { get; set; }
+	}
+}

--- a/src/LfMergeBridge/SerializableLfCommentRegarding.cs
+++ b/src/LfMergeBridge/SerializableLfCommentRegarding.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	[DataContract]
+	public class SerializableLfCommentRegarding
+	{
+		[DataMember] public string TargetGuid { get; set; }
+		[DataMember] public string Field { get; set; }
+		[DataMember] public string FieldNameForDisplay { get; set; }
+		[DataMember] public string FieldValue { get; set; }
+		[DataMember] public string InputSystem { get; set; }
+		[DataMember] public string InputSystemAbbreviation { get; set; }
+		[DataMember] public string Word { get; set; }
+		[DataMember] public string Meaning { get; set; }
+	}
+}

--- a/src/LfMergeBridge/SerializableLfCommentReply.cs
+++ b/src/LfMergeBridge/SerializableLfCommentReply.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
+{
+	[DataContract]
+	public class SerializableLfCommentReply
+	{
+		[DataMember] public string Guid { get; set; }
+		[DataMember] public string AuthorNameAlternate { get; set; }
+		[DataMember] public SerializableLfAuthorInfo AuthorInfo { get; set; }  // Despite the name, this is used for DateCreated and Modified, not author info
+		[DataMember] public string Content { get; set; }
+		[DataMember] public bool IsDeleted { get; set; }
+		[DataMember] public string UniqId { get; set; }  // Called "id" in Mongo, but called "UniqId" in LfMerge
+	}
+}

--- a/src/LfMergeBridge/packages.config
+++ b/src/LfMergeBridge/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+</packages>

--- a/src/LibTriboroughBridge-ChorusPlugin/ActionType.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/ActionType.cs
@@ -17,6 +17,9 @@ namespace LibTriboroughBridgeChorusPlugin
 
 		LanguageForgeAuxiliaryCommit,
 
+		LanguageForgeGetChorusNotes,
+		LanguageForgeWriteToChorusNotes,
+
 		Obtain,
 		ObtainLift,
 

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/StringToActionTypeConverter.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/StringToActionTypeConverter.cs
@@ -15,6 +15,8 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure.ActionHandlers
 		private const string Language_Forge_Clone = "Language_Forge_Clone";
 		private const string Language_Forge_Update_To_Long_Hash = "Language_Forge_Update_To_Long_Hash";
 		private const string Language_Forge_Auxiliary_Commit = "Language_Forge_Auxiliary_Commit";
+		private const string Language_Forge_Get_Chorus_Notes = "Language_Forge_Get_Chorus_Notes";
+		private const string Language_Forge_Write_To_Chorus_Notes = "Language_Forge_Write_To_Chorus_Notes";
 
 		// Support for FLEx
 		// Support for both FLEx full project & LIFT
@@ -50,6 +52,10 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure.ActionHandlers
 					return ActionType.LanguageForgeUpdateToLongHash;
 				case Language_Forge_Auxiliary_Commit:
 					return ActionType.LanguageForgeAuxiliaryCommit;
+				case Language_Forge_Get_Chorus_Notes:
+					return ActionType.LanguageForgeGetChorusNotes;
+				case Language_Forge_Write_To_Chorus_Notes:
+					return ActionType.LanguageForgeWriteToChorusNotes;
 
 				case obtain:
 					return ActionType.Obtain;


### PR DESCRIPTION
This PR needs to be merged before the corresponding LfMerge PR is merged, since LfMerge will depend on having an LfMergeBridge DLL that knows the new GetChorusNotes and WriteToChorusNotes actions.

There are no unit tests yet, but I'm creating the PR anyway so that we can kick off a TeamCity build and make sure that it compiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/149)
<!-- Reviewable:end -->
