### PR TITLE
LT-16680:Send Receive menu unavailable while FLExBridge installed

### DIFF
--- a/build/FLExBridge.build.win.proj
+++ b/build/FLExBridge.build.win.proj
@@ -9,7 +9,7 @@
   <UsingTask TaskName="FileUpdate" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll"/>
   <UsingTask TaskName="NUnitTeamCity" AssemblyFile="$(teamcity_dotnet_nunitlauncher_msbuild_task)"/>
   <!-- From http://msbuildtasks.tigris.org/ Has UnZip task -->
-  <Import Project="$(MSBuildExtensionsPath)\MSBuildCommunityTasks\MSBuild.Community.Tasks.Targets"/>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\tools\MSBuild.Community.Tasks.Targets"/>
 
   <!-- ***************** Main build ***************** -->
   <PropertyGroup>
@@ -55,7 +55,7 @@
   </Target>
 
   <Target Name="Compile" DependsOnTargets="RestorePackages">
-	<MSBuild Projects="$(RootDir)/$(Solution)" Targets="Build" Properties="Configuration=$(Configuration)"/>
+	<MSBuild Projects="$(RootDir)/$(Solution)" Targets="Build" Properties="Configuration=$(Configuration);Platform=Any CPU"/>
   </Target>
 
   <!-- ***************** Testing ***************** -->

--- a/build/TestInstallerBuild.bat
+++ b/build/TestInstallerBuild.bat
@@ -1,6 +1,6 @@
-call "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
+call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
 
 pushd .
-MSbuild FLExBridge.build.win.proj /target:Installer /property:teamcity_build_checkoutDir=..\  /property:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /property:BUILD_NUMBER="0.3.1" /property:Minor="1"
+MSbuild FLExBridge.build.win.proj /target:Installer /p:Configuration=Debug /p:Platform="Any CPU" /p:teamcity_build_checkoutDir=..\  /p:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /p:BUILD_NUMBER="0.3.1" /p:Minor="1" /p:BUILD_VCS_NUMBER=0
 popd
 PAUSE

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -110,7 +110,7 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 			  <File Id="TriboroughBridgeChorusPlugin.pdb" Name="TriboroughBridge-ChorusPlugin.pdb" KeyPath="yes" Source="..\..\output\Release\TriboroughBridge-ChorusPlugin.pdb"/>
 			</Component>
 			<Component Id="RegInstallationDir" Guid="C1EDBBD7-E382-11DE-8A39-0800200C9A66">
-			  <RegistryKey Id="keyFLExBridge.exe" Action="createAndRemoveOnUninstall" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FLEX Bridge\8">
+			  <RegistryKey Id="keyFLExBridge.exe" Action="createAndRemoveOnUninstall" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FLEX Bridge\9">
 				<RegistryValue Id="FLExBridgeInstallationDir" Type="string" Value="[INSTALLDIR]" Name="InstallationDir"/>
 			  </RegistryKey>
 			</Component>
@@ -126,16 +126,17 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 			  <File Id="LibChorus.pdb" Name="LibChorus.pdb" KeyPath="yes" Source="..\..\output\Release\LibChorus.pdb"/>
 			</Component>
 
-			<!-- Desired Palaso pdb files not in the Chorus merge module. -->
-			<Component Id="Palaso.pdb" Guid="C1EDE2F8-E382-11DE-8A39-0800200C9A66">
-			  <File Id="Palaso.pdb" Name="Palaso.pdb" KeyPath="yes" Source="..\..\output\Release\Palaso.pdb"/>
+			<!-- Desired SIL pdb files not in the Chorus merge module. -->
+			<Component Id="SIL.Windows.Forms.pdb" Guid="0FBA86CD-E104-4117-A3DB-135C1FF22FEC">
+			 <File Id="SIL.Windows.Forms.pdb" Name="SIL.Windows.Forms.pdb" KeyPath="yes" Source="..\..\output\Release\SIL.Windows.Forms.pdb"/>
 			</Component>
-			<Component Id="PalasoUIWindowsForms.pdb" Guid="C1EDE2F9-E382-11DE-8A39-0800200C9A66">
-			  <File Id="PalasoUIWindowsForms.pdb" Name="PalasoUIWindowsForms.pdb" KeyPath="yes" Source="..\..\output\Release\PalasoUIWindowsForms.pdb"/>
+			<Component Id="SIL.Core.pdb" Guid="1C51C23E-DE70-4200-8D45-6795B95A706F">
+			 <File Id="SIL.Core.pdb" Name="SIL.Core.pdb" KeyPath="yes" Source="..\..\output\Release\SIL.Core.pdb"/>
 			</Component>
-			<Component Id="Palaso.Lift.pdb" Guid="C1EE09F3-E382-11DE-8A39-0800200C9A66">
-			  <File Id="Palaso.Lift.pdb" Name="Palaso.Lift.pdb" KeyPath="yes" Source="..\..\output\Release\Palaso.Lift.pdb"/>
+			<Component Id="SIL.Lift.pdb" Guid="6850EBC7-50B6-4B09-85D7-5DC7EEC39E76">
+			 <File Id="SIL.Lift.pdb" Name="SIL.Lift.pdb" KeyPath="yes" Source="..\..\output\Release\SIL.Lift.pdb"/>
 			</Component>
+
 
 			<Component Id="NetSparkle.Net40.dll" Guid="C1EE311B-E382-11DE-8A39-0800200C9A66">
 			  <File Id="NetSparkle.Net40.dll" Name="NetSparkle.Net40.dll" KeyPath="yes" Source="..\..\output\Release\NetSparkle.Net40.dll"/>
@@ -195,9 +196,9 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 	  <ComponentRef Id="LibChorus.pdb"/>
 	  <ComponentRef Id="Chorus.pdb"/>
 	  <ComponentRef Id="ChorusMerge.pdb"/>
-	  <ComponentRef Id="Palaso.pdb"/>
-	  <ComponentRef Id="Palaso.Lift.pdb"/>
-	  <ComponentRef Id="PalasoUIWindowsForms.pdb"/>
+	  <ComponentRef Id="SIL.Windows.Forms.pdb"/>
+	  <ComponentRef Id="SIL.Core.pdb"/>
+	  <ComponentRef Id="SIL.Lift.pdb"/>
 
 	  <ComponentRef Id="NetSparkle.Net40.dll"/>
 	  <ComponentRef Id="L10NSharp.dll"/>

--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -29,32 +29,32 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 	<MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version of FLEx Bridge is already installed. Setup will now exit." Schedule="afterInstallValidate"/>
 
 	<Property Id="MANUFACTURERREGKEY">SIL</Property>
-	<!-- The following will set properties A[FW8INSTALLDIR] and B[FW8DEVINSTALLDIR] to the result of two different registry searches.
-	If the search for B[FW8DEVINSTALLDIR] was successful, it overrides the value of A[FW8INSTALLDIR] with the value of B[FW8DEVINSTALLDIR].
+	<!-- The following will set properties A[FW9INSTALLDIR] and B[FW9DEVINSTALLDIR] to the result of two different registry searches.
+	If the search for B[FW9DEVINSTALLDIR] was successful, it overrides the value of A[FW9INSTALLDIR] with the value of B[FW9DEVINSTALLDIR].
 	See: http://stackoverflow.com/questions/1690162/wix-set-a-property-based-on-a-condition -->
-	<Property Id="FW8INSTALLDIR">
+	<Property Id="FW9INSTALLDIR">
 	  <!-- Real users and devs have this registry entry. But, a dev machine has it set to DistFiles. -->
-	  <RegistrySearch Id="SearchForFW8" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FieldWorks\8" Name="RootCodeDir" Type="raw"/>
+	  <RegistrySearch Id="SearchForFW9" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FieldWorks\9" Name="RootCodeDir" Type="raw"/>
 	</Property>
 	<Property Id="FIELDWORKSMINIMUMINSTALLEDVERSION">
-	  <DirectorySearch Id="FWVersion" Path="[FW8INSTALLDIR]">
+	  <DirectorySearch Id="FWVersion" Path="[FW9INSTALLDIR]">
 		<!-- 8.0.3.41467 was the actual number the day the FW Beta 4 was released, but I understand one then needs to go one notch under that to findit. -->
 		<FileSearch Name="FieldWorks.exe" MinVersion="8.0.3.41466"/>
 	  </DirectorySearch>
 	</Property>
-	<Property Id="DEVFW8BUILDDIR">
+	<Property Id="DEVFW9BUILDDIR">
 	  <!-- Devs (only) have this registry entry. -->
-	  <RegistrySearch Id="SearchForFW8DevDir" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FieldWorks\8" Name="FwExeDir" Type="raw"/>
+	  <RegistrySearch Id="SearchForFW9DevDir" Root="HKLM" Key="SOFTWARE\[MANUFACTURERREGKEY]\FieldWorks\9" Name="FwExeDir" Type="raw"/>
 	</Property>
 	<Property Id="DEVFIELDWORKSMINIMUMINSTALLEDVERSION">
-	  <DirectorySearch Id="DevFWVersion" Path="[DEVFW8BUILDDIR]">
+	  <DirectorySearch Id="DevFWVersion" Path="[DEVFW9BUILDDIR]">
 					<!-- 8.0.3.41467 was the actual number the day the FW Beta 4 was released, but I understand one then needs to go one notch under that to findit. -->
 		<FileSearch Name="FieldWorks.exe" MinVersion="8.0.3.41466"/>
 	  </DirectorySearch>
 	</Property>
 
 	<!-- Use the dev entry, but only if set.
-	<SetProperty Id="FW8INSTALLDIR" Before="SetFIELDWORKSMINIMUMINSTALLEDVERSION" Value="[DEVFW8BUILDDIR]">DEVFW8BUILDDIR</SetProperty> -->
+	<SetProperty Id="FW9INSTALLDIR" Before="SetFIELDWORKSMINIMUMINSTALLEDVERSION" Value="[DEVFW9BUILDDIR]">DEVFW9BUILDDIR</SetProperty> -->
 	<SetProperty Id="FIELDWORKSMINIMUMINSTALLEDVERSION" Before="LaunchConditions" Value="[DEVFIELDWORKSMINIMUMINSTALLEDVERSION]">DEVFIELDWORKSMINIMUMINSTALLEDVERSION</SetProperty>
 
 	<!--


### PR DESCRIPTION
*Updated the setting for FLExBridge
*Changed the FLExBridge version number to 9 for registry
*Removed unused Palaso related files.
*Included SIL related files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/153)
<!-- Reviewable:end -->
