### PR TITLE
Fix TeamCity Builds (NuGet)

### DIFF
--- a/build/FLExBridge.build.win.proj
+++ b/build/FLExBridge.build.win.proj
@@ -9,7 +9,10 @@
   <UsingTask TaskName="FileUpdate" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll"/>
   <UsingTask TaskName="NUnitTeamCity" AssemblyFile="$(teamcity_dotnet_nunitlauncher_msbuild_task)"/>
   <!-- From http://msbuildtasks.tigris.org/ Has UnZip task -->
-  <Import Project="..\packages\MSBuildTasks.1.5.0.235\tools\MSBuild.Community.Tasks.Targets"/>
+  <PropertyGroup>
+	<MSBuildTasksTargets>..\packages\MSBuildTasks.1.5.0.235\tools\MSBuild.Community.Tasks.Targets"</MSBuildTasksTargets>
+  </PropertyGroup
+  <Import Project="$(MSBuildTasksTargets)" Condition="Exists('$(MSBuildTasksTargets)')"/>
 
   <!-- ***************** Main build ***************** -->
   <PropertyGroup>


### PR DESCRIPTION
The MsBuild.Community.Tasks.Targets file is unavailable until it has been NuGotten.
- Restore NuGet packages first (TC Config)
- Import the .Targets file only if it exists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/157)
<!-- Reviewable:end -->
