### PR TITLE
LF comments become questions rather than notes

### DIFF
--- a/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
@@ -259,7 +259,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 			{
 				author = genericAuthorName;
 			}
-			var result = new Annotation("note", MakeFlexRefURL(ownerGuidStr, ownerShortName), guid, "ignored");
+			var result = new Annotation("question", MakeFlexRefURL(ownerGuidStr, ownerShortName), guid, "ignored");
 			result.AddMessage(author, LfStatusToChorusStatus(status), content);
 			return result;
 		}


### PR DESCRIPTION
Chorus status of "note" is used for things like conflict reports, etc.; anything created by users in FLEx has the status of "question", and LF comments should be the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/179)
<!-- Reviewable:end -->
