### PR TITLE
Fix fixutf8

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,6 +25,8 @@ case "$1" in
 			ARCH="$(/usr/bin/arch)"
 			unzip Mercurial-${ARCH}.zip
 			chmod +x Mercurial/hg
+			# Turn off any existing fixutf8 extensions with potentially problematic paths
+			perl -pi -e "/^fixutf8/ && s/^/#/" Mercurial/mercurial.ini
 			echo "fixutf8=/usr/lib/flexbridge/MercurialExtensions/fixutf8/fixutf8.py" >> Mercurial/mercurial.ini
 		fi
 


### PR DESCRIPTION
The fixutf8 extension appears to start off enabled with a relative
path. This doesn't work on Linux, and just adding a second line with
an absolute path doesn't fix it. So comment out any existing fixutf8
extension lines so we only have the one line with the absolute path.
Fixes LT-18796.