### PR TITLE
Split CopyExtraFiles target name by OS

### DIFF
--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -100,7 +100,9 @@
 		<ConfigFiles Include="$(RootDir)/lib/$(Configuration)/*.dll.config"/>
 	</ItemGroup>
 
-	<Target Name="CopyExtraFilesToOutput" Condition="'$(OS)'!='Windows_NT'">
+	<Target Name="CopyExtraFilesToOutput" DependsOnTargets="CopyExtraFilesToOutputWindows;CopyExtraFilesToOutputLinux"/>
+
+	<Target Name="CopyExtraFilesToOutputLinux" Condition="'$(OS)'!='Windows_NT'">
 		<Copy SourceFiles="@(EnchantFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 		<Copy SourceFiles="@(IcuDotNetFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/localizations"/>
@@ -109,7 +111,7 @@
 		<Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 	</Target>
 
-	<Target Name="CopyExtraFilesToOutput" Condition="'$(OS)'=='Windows_NT'">
+	<Target Name="CopyExtraFilesToOutputWindows" Condition="'$(OS)'=='Windows_NT'">
 		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/localizations"/>
 	</Target>
 


### PR DESCRIPTION
And arrange so the right one gets called depending on the OS.
The CopyExtraFilesToOutput target was getting skipped on Linux,
resulting in localization files not being copied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/189)
<!-- Reviewable:end -->
