### PR TITLE
Ignore problematic DllImport references

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,4 +26,6 @@ override_dh_clideps:
 		--exclude-moduleref=libgeckofix.so --exclude-moduleref=Geckofx-Core.dll \
 		--exclude-moduleref=libgobject-2.0.so --exclude-moduleref=libgio-2.0.so \
 		--exclude-moduleref=libglib-2.0.so --exclude-moduleref=libxklavier \
+		--exclude-moduleref=MAPI32.DLL \
+		--exclude-moduleref=__Internal \
 		--exclude-moduleref=Autofac --exclude-moduleref=NDesk.DBus


### PR DESCRIPTION
MAPI32.DLL was Windows-only in MAPIHelper.cs before #if !MONO was
removed.
__Internal probably should have been ignored by dh_clideps without us
having to say so. This is in Platform.cs.
This fixes a Linux packaging error.

Both Platform.cs and MAPIHelper.cs are in libpalaso, and this problem
was introduced to flexbridge packaging when we switched to use the
master branch of libpalaso.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/190)
<!-- Reviewable:end -->
