### PR TITLE
Update run-app

### DIFF
--- a/lib/common/run-app
+++ b/lib/common/run-app
@@ -6,7 +6,7 @@ scriptdir=$(dirname "$0")
 prefix=$(cd "$scriptdir/../.."; /bin/pwd)
 lib=$prefix/lib/flexbridge
 fwlib=$prefix/lib/fieldworks
-MONO_PREFIX=/opt/mono4-sil
+MONO_PREFIX=${MONO_PREFIX:-/opt/mono4-sil}
 
 # Allow running ChorusHub as a mono service
 
@@ -40,8 +40,11 @@ esac
 if [ "$RUNMODE" = "INSTALLED" ]; then
 	BASE=$fwlib
 else
-	MONO_PREFIX=/usr/local
 	BASE=${HOME}/fwrepo/fw
+fi
+
+if [[ -d "$BASE" ]]; then
+	echo >&2 flexbridge run-app: Warning: Assuming non-existent base "$BASE"
 fi
 
 # Add packaged mono items to paths
@@ -49,7 +52,6 @@ fi
 PKG_CONFIG_PATH="${MONO_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 PATH="${MONO_PREFIX}/bin:${PATH}"
 LD_LIBRARY_PATH="${MONO_PREFIX}/lib:${LD_LIBRARY_PATH}"
-PKG_CONFIG_PATH="${MONO_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 MONO_GAC_PREFIX="${MONO_PREFIX}:/usr"
 
 if [ "$RUNMODE" = "INSTALLED" ]


### PR DESCRIPTION
We don't use mono from /usr/local any more.
Put in a warning since there is an assumption about where FW source
code is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/197)
<!-- Reviewable:end -->
