### PR TITLE
Set build number on TC

### DIFF
--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -146,6 +146,8 @@
 			<Output TaskParameter="Lines" PropertyName="Version" />
 		</ReadLinesFromFile>
 		<Message Text="Version: $(Version)" Importance="high"/>
+		<Message Text="##teamcity[buildNumber '$(Version).$(BUILD_NUMBER).$(BUILD_VCS_NUMBER)']"
+			Condition="'$(teamcity_version)' != ''"/>
 	</Target>
 
 	<ItemGroup>


### PR DESCRIPTION
This will cause the displayed build number to match the version
that the assemblies have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/205)
<!-- Reviewable:end -->
