### PR TITLE
Remove version numbers from installer artifacts

### DIFF
--- a/build/WixPatchableInstaller.targets
+++ b/build/WixPatchableInstaller.targets
@@ -207,6 +207,10 @@
 			<InstallerFiles Include="$(BaseBuildDir)/**/$(SafeApplicationName)_*.msi"/>
 		</ItemGroup>
 		<Move SourceFiles="@(InstallerFiles)" DestinationFolder="$(InstallersBaseDir)"/>
+		<!-- The FieldWorks installer wants a stable installer name -->
+		<Move SourceFiles="$(InstallersBaseDir)/$(SafeApplicationName)_$(BuildVersion)_Offline.exe" DestinationFiles="$(InstallersBaseDir)/$(SafeApplicationName)_Offline.exe"/>
+		<Move SourceFiles="$(InstallersBaseDir)/$(SafeApplicationName)_$(BuildVersion)_Online.exe" DestinationFiles="$(InstallersBaseDir)/$(SafeApplicationName)_Online.exe"/>
+		<Move SourceFiles="$(InstallersBaseDir)/$(SafeApplicationName)_$(BuildVersion).msi" DestinationFiles="$(InstallersBaseDir)/$(SafeApplicationName).msi"/>
 	</Target>
 
 	<Target Name="BuildProductPatchMsp" DependsOnTargets="InstallerVersionNumbers">

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2017 SIL International. All rights reserved.
+// Copyright (C) 2010-2018 SIL International. All rights reserved.
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Reflection;
@@ -7,10 +7,10 @@ using System.Reflection;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCompany("SIL International")]
 [assembly: AssemblyProduct("FLEx Bridge")]
-[assembly: AssemblyCopyright("Copyright (c) SIL International 2010-2017")]
+[assembly: AssemblyCopyright("Copyright (c) SIL International 2010-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyInformationalVersion("3.0.1.0")]


### PR DESCRIPTION
our only client should be the FLEx installer, which downloads
our artifacts from what it expects to be a stable URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/215)
<!-- Reviewable:end -->
