### PR TITLE
Fix bug when annotations contained no messages

### DIFF
--- a/src/LfMergeBridge/LanguageForgeGetChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeGetChorusNotesActionHandler.cs
@@ -153,6 +153,7 @@ namespace LfMergeBridge
 		{
 			return from repo in AnnotationRepository.CreateRepositoriesFromFolder(projectDir, progress)
 				from ann in repo.GetAllAnnotations()
+				where ann.Messages.FirstOrDefault() != null  // Some annotations have been known to have NO messages; we skip those
 				select ann;
 		}
 

--- a/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
@@ -210,7 +210,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""closed""
-			date=""2018-02-01T12:13:14Z""
+			date=""2018-02-01T12:13:14-06:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -260,7 +260,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14Z""
+			date=""2018-02-01T12:13:14-06:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -294,7 +294,7 @@ namespace LfMergeBridgeTests
 @"		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14Z""
+			date=""2018-02-01T12:13:14-06:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715401"">LF comment on F</message>",
 				"1687b882-97c9-4ca0-9bc3-2a0511715400")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}

--- a/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
@@ -49,7 +49,7 @@ namespace LfMergeBridgeTests
 		public void Setup()
 		{
 			GuidProvider.SetProvider(new ReproducibleGuidProvider("1687b882-97c9-4ca0-9bc3-2a05117154{0:00}"));
-			DateTimeProvider.SetProvider(new ReproducibleDateTimeProvider(new DateTime(2018, 02, 01, 12, 13, 14, DateTimeKind.Local)));
+			DateTimeProvider.SetProvider(new ReproducibleDateTimeProvider(new DateTime(2018, 02, 01, 12, 13, 14, DateTimeKind.Utc)));
 		}
 
 		[TearDown]
@@ -210,7 +210,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""closed""
-			date=""2018-02-01T12:13:14-06:00""
+			date=""2018-02-01T12:13:14+00:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -260,7 +260,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14-06:00""
+			date=""2018-02-01T12:13:14+00:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -294,7 +294,7 @@ namespace LfMergeBridgeTests
 @"		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14-06:00""
+			date=""2018-02-01T12:13:14+00:00""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715401"">LF comment on F</message>",
 				"1687b882-97c9-4ca0-9bc3-2a0511715400")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}

--- a/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
@@ -210,7 +210,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""closed""
-			date=""2018-02-01T12:13:14+00:00""
+			date=""2018-02-01T12:13:14Z""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -260,7 +260,7 @@ namespace LfMergeBridgeTests
 		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14+00:00""
+			date=""2018-02-01T12:13:14Z""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -294,7 +294,7 @@ namespace LfMergeBridgeTests
 @"		<message
 			author=""Language Forge""
 			status=""open""
-			date=""2018-02-01T12:13:14+00:00""
+			date=""2018-02-01T12:13:14Z""
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715401"">LF comment on F</message>",
 				"1687b882-97c9-4ca0-9bc3-2a0511715400")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}


### PR DESCRIPTION
Some annotations in real user data have NO `<message>` elements inside them, which causes the merge to fail and the project to be put on hold. This is not *supposed* to happen, but it does, so we need to deal with it. This commit is the simplest way I've found to do so: it skips any such annotations, because we can't extract any meaningful data from them anyway (and trying to do so ends up causing other issues).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/220)
<!-- Reviewable:end -->
