### PR TITLE
Fix LT-19080: Add Chorus Hub download link in about.htm

### DIFF
--- a/DistFiles/about.htm
+++ b/DistFiles/about.htm
@@ -56,6 +56,10 @@
 					<tr>
 						<td colspan="2">Copyright &copy; 2010-DEV_RELEASE_YEAR SIL International</td>
 					</tr>
+					<tr>
+						<td><strong>Chorus Hub:</strong></td>
+						<td><a href="https://software.sil.org/chorushub/download" target="_blank">Download Chorus Hub</a></td>
+					</tr>
 				</tbody>
 			</table>
 		  </td>


### PR DESCRIPTION
* Added Chorus Hub download link in about.htm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/226)
<!-- Reviewable:end -->
