### PR TITLE
add FLEXBRIDGEDIR Env Var to Win installer

### DIFF
--- a/src/InstallerOverrides/CustomComponents.wxi
+++ b/src/InstallerOverrides/CustomComponents.wxi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+	<DirectoryRef Id="TARGETDIR">
+		<Component Id="InstallDirEnvVar" Guid="EEDDBBF6-7B37-4473-8D53-3081AB076399">
+			<Environment Id="InstallDirEnvVar" Name="FLEXBRIDGEDIR" Action="set" System="yes" Value="[APPFOLDER]" />
+		</Component>
+	</DirectoryRef>
+</Include>

--- a/src/InstallerOverrides/CustomFeatures.wxi
+++ b/src/InstallerOverrides/CustomFeatures.wxi
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
+	<!-- Always install the environment variable so all versions of FLEx can find FLEx Bridge. -->
+	<ComponentRef Id="InstallDirEnvVar"/>
 	<!-- Don't install shortcuts, but put them under a feature to keep the ICE validator happy. -->
 	<Feature Id='Shortcuts' Title='Start Menu Shortcut' Description='Creates a shortcut in the Start menu.' Level='0' ConfigurableDirectory='APPFOLDER' AllowAdvertise="no" InstallDefault="source" Absent='allow' TypicalDefault="install" >
 		<ComponentRef Id='ApplicationShortcutDesktop'/>


### PR DESCRIPTION
So that FLEx 8 can use the latest version of FLEx Bridge, which was designed to be found by FLEx 9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/239)
<!-- Reviewable:end -->
