### PR TITLE
 Fix crash if we don't have a .ChorusNotes file (LF-199)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ vcs_version
 icu4c.readme.txt
 gitversion.properties
 .idea/
+.vs/

--- a/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
@@ -67,6 +67,9 @@ namespace LfMergeBridge
 			var commentIdsThatNeedGuids = new Dictionary<string,string>();
 			var replyIdsThatNeedGuids = new Dictionary<string,string>();
 
+			if (commentsFromLF == null)
+				return;
+
 			foreach (KeyValuePair<string, SerializableLfComment> kvp in commentsFromLF)
 			{
 				string lfAnnotationObjectId = kvp.Key;
@@ -233,20 +236,8 @@ namespace LfMergeBridge
 
 		private AnnotationRepository MakePrimaryAnnotationRepository()
 		{
-			string fname = Path.Combine(ProjectDir, mainNotesFilenameStub);
-			EnsureFileExists(fname, "This is a stub file to provide an attachment point for " + mainNotesFilename);
-			return AnnotationRepository.FromFile("id", fname, new NullProgress());
-		}
-
-		private void EnsureFileExists(string filename, string contentToCreateFileWith)
-		{
-			if (!File.Exists(filename))
-			{
-				using (var writer = new StreamWriter(filename, false, Encoding.UTF8))
-				{
-					writer.WriteLine(contentToCreateFileWith);
-				}
-			}
+			return AnnotationRepository.FromFile("id",
+				Path.Combine(ProjectDir, mainNotesFilenameStub), new NullProgress());
 		}
 
 		private Annotation CreateAnnotation(string content, string guidStr, string author, string status, string ownerGuidStr, string ownerShortName)

--- a/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeWriteToChorusNotesActionHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT) (See: license.rtf file)
 
 using System;
@@ -78,7 +78,7 @@ namespace LfMergeBridge
 				{
 					if (lfAnnotation == null)
 					{
-						LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping null annotation with MongoId {0}",
+						LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("Skipping null annotation with MongoId {0}",
 							lfAnnotationObjectId ?? "(null ObjectId)"));
 					}
 					else
@@ -86,7 +86,7 @@ namespace LfMergeBridge
 						// We don't have a C# 6 compiler in our build infrastructure, so we have to do this the hard(er) way.
 						string guidForLog = lfAnnotation == null ? "(no guid)" : lfAnnotation.Guid ?? "(no guid)";
 						string contentForLog = lfAnnotation == null ? "(no content)" : lfAnnotation.Content ?? "(no content)";
-						LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping deleted annotation {0} containing content \"{1}\"",
+						LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("Skipping deleted annotation {0} containing content \"{1}\"",
 							guidForLog, contentForLog));
 						// The easy way would have been able to skip creating guidForLog and contentForLog; that would have looked like:
 						// LfMergeBridge.LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("Skipping deleted annotation {0} containing content \"{1}\"",
@@ -113,10 +113,10 @@ namespace LfMergeBridge
 				}
 			}
 
-			LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("New comment ID->Guid mappings: {0}",
-				String.Join(";", commentIdsThatNeedGuids.Select(kv => String.Format("{0}={1}", kv.Key, kv.Value)))));
-			LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, String.Format("New reply ID->Guid mappings: {0}",
-				String.Join(";", replyIdsThatNeedGuids.Select(kv => String.Format("{0}={1}", kv.Key, kv.Value)))));
+			LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("New comment ID->Guid mappings: {0}",
+				string.Join(";", commentIdsThatNeedGuids.Select(kv => string.Format("{0}={1}", kv.Key, kv.Value)))));
+			LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("New reply ID->Guid mappings: {0}",
+				string.Join(";", replyIdsThatNeedGuids.Select(kv => string.Format("{0}={1}", kv.Key, kv.Value)))));
 
 			SaveReposIfNeeded(annRepos, progress);
 		}
@@ -131,21 +131,14 @@ namespace LfMergeBridge
 
 		private string LfStatusToChorusStatus(string lfStatus)
 		{
-			if (lfStatus == SerializableLfComment.Resolved)
-			{
-				return Chorus.notes.Annotation.Closed;
-			}
-			else
-			{
-				return Chorus.notes.Annotation.Open;
-			}
+			return lfStatus == SerializableLfComment.Resolved ? Annotation.Closed : Annotation.Open;
 		}
 
 		private void SetChorusAnnotationMessagesFromLfReplies(Annotation chorusAnnotation, SerializableLfComment annotationInfo,
 			string annotationObjectId, Dictionary<string,string> uniqIdsThatNeedGuids, Dictionary<string,string> commentIdsThatNeedGuids)
 		{
 			// Any LF comments that do NOT yet have GUIDs need them set from the corresponding Chorus annotation
-			if (String.IsNullOrEmpty(annotationInfo.Guid) && !String.IsNullOrEmpty(annotationObjectId))
+			if (string.IsNullOrEmpty(annotationInfo.Guid) && !string.IsNullOrEmpty(annotationObjectId))
 			{
 				commentIdsThatNeedGuids[annotationObjectId] = chorusAnnotation.Guid;
 			}

--- a/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 SIL International
+// Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -27,7 +27,9 @@ namespace LfMergeBridgeTests
 				"LanguageForgeWriteToChorusNotesActionHandlerTests"));
 			var dir = Path.Combine(_baseDir.Path, "test-project");
 			Directory.CreateDirectory(dir);
-			File.WriteAllText(Path.Combine(dir, "Lexicon.fwstub.ChorusNotes"), notes);
+
+			if (notes != null)
+				File.WriteAllText(Path.Combine(dir, "Lexicon.fwstub.ChorusNotes"), notes);
 			return dir;
 		}
 
@@ -298,6 +300,27 @@ namespace LfMergeBridgeTests
 			guid=""1687b882-97c9-4ca0-9bc3-2a0511715401"">LF comment on F</message>",
 				"1687b882-97c9-4ca0-9bc3-2a0511715400")).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
+
+		/// <summary>
+		/// Empty project from LD so we don't have a *.ChorusNotes file. Shouldn't crash (LF-199).
+		/// </summary>
+		[Test]
+		public void NoChorusNotesFile()
+		{
+			// Setup
+			var projectDir = CreateTestProject(null);
+
+			_inputFile = new TempFile();
+
+			string forClient = null;
+			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
+
+			// Execute/Verify
+			Assert.That(
+				() => sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient),
+				Throws.Nothing);
+		}
+
 	}
 }
 


### PR DESCRIPTION
If we don't have a .ChorusNotes file we don't have to create one in
LfMergeBridge because that is done in Chorus. Just creating a text file
caused a crash when Chorus tried to read the file as XML.

The .ChorusNotes file won't exist if the user sends an empty project
(without any entries) in FLEx and we S/R to LF.

This change also adds a unit test for the case when the .ChorusNotes file
is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/240)
<!-- Reviewable:end -->
