### PR TITLE
Add file handler for lexicon settings

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -12,6 +12,7 @@ using LibFLExBridgeChorusPlugin.Contexts.Linguistics;
 using LibFLExBridgeChorusPlugin.Contexts.Scripture;
 using LibFLExBridgeChorusPlugin.Infrastructure;
 using LibFLExBridgeChorusPlugin.DomainServices;
+using SIL.IO;
 using SIL.Progress;
 
 namespace LibFLExBridgeChorusPlugin.Contexts
@@ -28,6 +29,7 @@ namespace LibFLExBridgeChorusPlugin.Contexts
 			AnthropologyDomainServices.WriteNestedDomainData(progress, writeVerbose, pathRoot, wellUsedElements, classData, guidToClassMapping);
 			ScriptureDomainServices.WriteNestedDomainData(progress, writeVerbose, pathRoot, wellUsedElements, classData, guidToClassMapping);
 			GeneralDomainServices.WriteNestedDomainData(progress, writeVerbose, pathRoot, wellUsedElements, classData, guidToClassMapping);
+			CopySupportingSettingsFilesIntoRepo(progress, writeVerbose, pathRoot);
 		}
 
 		internal static SortedDictionary<string, XElement> PutHumptyTogetherAgain(IProgress progress, bool writeVerbose, string pathRoot)
@@ -50,7 +52,7 @@ namespace LibFLExBridgeChorusPlugin.Contexts
 			{
 				retval[highLevelElement.Attribute(FlexBridgeConstants.GuidStr).Value.ToLowerInvariant()] = highLevelElement;
 			}
-
+			CopySupportingSettingsFilesIntoProjectFolder(progress, writeVerbose, pathRoot);
 			return retval;
 		}
 
@@ -172,6 +174,34 @@ namespace LibFLExBridgeChorusPlugin.Contexts
 
 			return (propElement == null) ? new List<string>() : (from osEl in propElement.Elements(FlexBridgeConstants.Objsur)
 																 select osEl.Attribute(FlexBridgeConstants.GuidStr).Value.ToLowerInvariant()).ToList();
+		}
+
+		private static void CopySupportingSettingsFilesIntoRepo(IProgress progress, bool writeVerbose, string pathRoot)
+		{
+			progress.WriteMessage("Copying settings files...");
+			// copy the dictionary configuration files into the .hg included repo
+			var dictionaryConfigFolder = Path.Combine(pathRoot, "ConfigurationSettings");
+			DirectoryHelper.Copy(dictionaryConfigFolder, Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings"), true);
+			// copy the lexicon settings files into the.hg included repo
+			var sharedSettingsFolder = Path.Combine(pathRoot, "SharedSettings");
+			DirectoryHelper.Copy(sharedSettingsFolder, Path.Combine(pathRoot, "CachedSettings", "SharedSettings"), true);
+			// copy the writing system files into the .hg included repo
+			var wsFolder = Path.Combine(pathRoot, "WritingSystems");
+			DirectoryHelper.Copy(wsFolder, Path.Combine(pathRoot, "CachedSettings", "WritingSystems"), true);
+		}
+
+		private static void CopySupportingSettingsFilesIntoProjectFolder(IProgress progress, bool writeVerbose, string pathRoot)
+		{
+			progress.WriteMessage("Copying settings files...");
+			// copy the dictionary configuration files out ofthe .hg included repo
+			var dictionaryConfigFolder = Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings");
+			DirectoryHelper.Copy(dictionaryConfigFolder, Path.Combine(pathRoot, "ConfigurationSettings"), true);
+			// copy the lexicon settings files into the.hg included repo
+			var sharedSettingsFolder = Path.Combine(pathRoot, "CachedSettings", "SharedSettings");
+			DirectoryHelper.Copy(sharedSettingsFolder, Path.Combine(pathRoot, "SharedSettings"), true);
+			// copy the writing system files into the .hg included repo
+			var wsFolder = Path.Combine(pathRoot, "CachedSettings", "WritingSystems");
+			DirectoryHelper.Copy(wsFolder, Path.Combine(pathRoot, "WritingSystems"), true);
 		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPlugin/Contexts/General/GeneralDomainBoundedContext.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Contexts/General/GeneralDomainBoundedContext.cs
@@ -53,7 +53,7 @@ namespace LibFLExBridgeChorusPlugin.Contexts.General
 
 			// LP Annotations (OC). Who still uses them? If all else fails, or they are used by several BCs, then store them in one file here.
 			// [FLExAnnotations.annotation: new ext]
-			// OJO! Sig is "CmAnnotation", which is abtract class, so handle like in Discourse-land.
+			// OJO! Sig is "CmAnnotation", which is abstract class, so handle like in Discourse-land.
 			owningPropElement = langProjElement.Element(FlexBridgeConstants.Annotations);
 			if (owningPropElement != null && owningPropElement.HasElements)
 			{

--- a/src/LibFLExBridge-ChorusPlugin/Handling/Common/ProjectLexiconSettingsStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/Common/ProjectLexiconSettingsStrategy.cs
@@ -35,7 +35,7 @@ namespace LibFLExBridgeChorusPlugin.Handling.Common
 			var writingSystemsElem = document.Root.Element("WritingSystems");
 			if (writingSystemsElem == null)
 			{
-				return "Lexicon settings file has no writing systems elements.";
+				return "Lexicon settings file has no writing systems element.";
 			}
 			var wsIdSet = new HashSet<string>();
 			foreach (var writingSystemElem in writingSystemsElem.Elements("WritingSystem"))
@@ -98,12 +98,12 @@ namespace LibFLExBridgeChorusPlugin.Handling.Common
 
 			private void SetAttrToFalseIfNotFound(string attName, XmlNode toChange)
 			{
-				if (toChange?.Attributes != null)
+				if (toChange == null)
+					return;
+
+				if (toChange.Attributes?[attName] == null)
 				{
-					if (toChange.Attributes[attName] == null)
-					{
-						((XmlElement)toChange).SetAttribute(attName, "false"); // The default value is false in SIL.Lexicon 
-					}
+					((XmlElement)toChange).SetAttribute(attName, "false"); // The default value is false in SIL.Lexicon 
 				}
 			}
 		}

--- a/src/LibFLExBridge-ChorusPlugin/Handling/Common/ProjectLexiconSettingsStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/Common/ProjectLexiconSettingsStrategy.cs
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Chorus.FileTypeHandlers;
+using Chorus.merge;
+using Chorus.merge.xml.generic;
+using Chorus.VcsDrivers.Mercurial;
+using LibFLExBridgeChorusPlugin.Infrastructure;
+using SIL.IO;
+
+namespace LibFLExBridgeChorusPlugin.Handling.Common
+{
+	[Export(typeof(IFieldWorksFileHandler))]
+	class ProjectLexiconSettingsStrategy : IFieldWorksFileHandler
+	{
+		public bool CanValidateFile(string pathToFile)
+		{
+			return PathHelper.CheckValidPathname(pathToFile, Extension);
+		}
+
+		public string ValidateFile(string pathToFile)
+		{
+			var document = XDocument.Load(pathToFile);
+			if (document.Root?.Name != "ProjectLexiconSettings")
+			{
+				return "Not a lexicon settings file.";
+			}
+
+			var writingSystemsElem = document.Root.Element("WritingSystems");
+			if (writingSystemsElem == null)
+			{
+				return "Lexicon settings file has no writing systems elements.";
+			}
+			var wsIdSet = new HashSet<string>();
+			foreach (var writingSystemElem in writingSystemsElem.Elements("WritingSystem"))
+			{
+				var idAttribute = writingSystemElem.Attribute("id");
+				if (idAttribute == null)
+				{
+					return "Writing system found with no id.";
+				}
+				if (wsIdSet.Contains(idAttribute.Value))
+				{
+					return $"Duplicate writing system found: {idAttribute.Value}";
+				}
+
+				wsIdSet.Add(idAttribute.Value);
+			}
+			// No errors found
+			return null;
+		}
+
+		public IChangePresenter GetChangePresenter(IChangeReport report, HgRepository repository)
+		{
+			return FieldWorksChangePresenter.GetCommonChangePresenter(report, repository);
+		}
+
+		public IEnumerable<IChangeReport> Find2WayDifferences(FileInRevision parent, FileInRevision child,
+			HgRepository repository)
+		{
+			return Xml2WayDiffService.ReportDifferences(repository, parent, child, null, "WritingSystem", "id");
+
+		}
+
+		public void Do3WayMerge(MetadataCache mdc, MergeOrder mergeOrder)
+		{
+			var merger = new XmlMerger(mergeOrder.MergeSituation) { EventListener = mergeOrder.EventListener };
+			var rootStrategy = ElementStrategy.CreateSingletonElement();
+			merger.MergeStrategies.SetStrategy("ProjectLexiconSettings", rootStrategy);
+			var writingSystemsStrategy = ElementStrategy.CreateSingletonElement();
+			merger.MergeStrategies.SetStrategy("WritingSystems", writingSystemsStrategy);
+			var writingSystemStrategy = ElementStrategy.CreateForKeyedElement("id", false);
+			writingSystemStrategy.IsAtomic = true;
+			merger.MergeStrategies.SetStrategy("WritingSystem", writingSystemStrategy);
+			var mergeResults = merger.MergeFiles(mergeOrder.pathToOurs, mergeOrder.pathToTheirs, mergeOrder.pathToCommonAncestor);
+			// Write merged data
+			File.WriteAllText(mergeOrder.pathToOurs, mergeResults.MergedNode.OuterXml, Encoding.UTF8);
+		}
+
+		public string Extension => "plsx";
+	}
+}

--- a/src/LibFLExBridge-ChorusPlugin/Handling/FieldWorksCommonFileHandler.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/FieldWorksCommonFileHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -53,7 +53,7 @@ namespace LibFLExBridgeChorusPlugin.Handling
 		/// <summary>
 		/// All callers merging FieldWorks data need to pass 'true', so the MDC will know about  any custom properties for their classes.
 		///
-		/// Non-object callers (currently only the merge of the custom property definitions themselves) shoudl pass 'false'.
+		/// Non-object callers (currently only the merge of the custom property definitions themselves) should pass 'false'.
 		/// </summary>
 		internal static void Do3WayMerge(MergeOrder mergeOrder, MetadataCache mdc, bool addcustomPropertyInformation)
 		{

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
+using System.Xml.Linq;
 
 namespace LibFLExBridgeChorusPlugin.Infrastructure
 {
@@ -190,5 +191,9 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 		internal const string ScrRefSystem = "ScrRefSystem";
 
 		/***** Relocate ones that get added below here. *****/
+		internal const string ProjectLexiconSettingsExtension = "plsx";
+		internal const string ProjectLexiconSettings = "LexiconSettings" + "." + ProjectLexiconSettingsExtension;
+		internal const string LexiconSettingsRoot = "ProjectLexiconSettings";
+
 	}
 }

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexFolderSystem.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexFolderSystem.cs
@@ -58,14 +58,16 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 			projectFolderConfiguration.IncludePatterns.Add("**.style");
 
 			// Misc required files.
-			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("ConfigurationSettings", "*.fwlayout"));
-			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("ConfigurationSettings", "**.fwdictconfig"));
-			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("ConfigurationSettings", "**Overrides.css"));
-			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("WritingSystemStore", "*.ldml"));
 			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("LinkedFiles", "AudioVisual", "**.*"));
 			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("LinkedFiles", "Others", "**.*"));
 			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("LinkedFiles", "Pictures", "**.*"));
 			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("SupportingFiles", "**.*"));
+			// Misc files moved for their protection (A file directly added to .hg can be removed if it doesn't validate)
+			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("CachedSettings", Path.Combine("ConfigurationSettings", "*.fwlayout")));
+			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("CachedSettings", Path.Combine("ConfigurationSettings", "**.fwdictconfig")));
+			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("CachedSettings", Path.Combine("ConfigurationSettings", "**Overrides.css")));
+			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("CachedSettings", Path.Combine("WritingSystemStore", "*.ldml")));
+			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("CachedSettings", Path.Combine("SharedSettings", "*.plsx")));
 
 			// Linguistics
 			projectFolderConfiguration.IncludePatterns.Add(Path.Combine("Linguistics", "Reversals", "**.reversal"));

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -116,6 +116,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Handling\Common\ProjectLexiconSettingsStrategy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DomainServices\FLExProjectSplitter.cs" />
     <Compile Include="DomainServices\FLExProjectUnifier.cs" />
@@ -253,10 +254,9 @@
   </Target>
   <!-- a few do-nothing targets to get rid of some warnings from GitVersionTask.targets. We get
     these warnings because this project doesn't yet use the new .csproj format. -->
-  <Target Name="GetAssemblyVersion"/>
-  <Target Name="GenerateNuspec"/>
-  <Target Name="_GenerateRestoreProjectSpec"/>
-
+  <Target Name="GetAssemblyVersion" />
+  <Target Name="GenerateNuspec" />
+  <Target Name="_GenerateRestoreProjectSpec" />
   <!-- Include the generated assembly info files for the purpose of Linux package building.
     We can't directly use the GitVersionTask there because we don't have a git repo when
     building the binary, so the task fails. Instead we generate the AssemblyInfo file when

--- a/src/LibFLExBridge-ChorusPluginTests/FieldWorksTestServices.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/FieldWorksTestServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -17,7 +17,7 @@ namespace LibFLExBridgeChorusPluginTests
 {
 	internal static class FieldWorksTestServices
 	{
-		internal const int ExpectedExtensionCount = 27;
+		internal const int ExpectedExtensionCount = 28;
 
 		internal static void RemoveTempFiles(ref TempFile ourFile, ref TempFile commonFile, ref TempFile theirFile)
 		{
@@ -144,6 +144,8 @@ namespace LibFLExBridgeChorusPluginTests
 			Assert.That(eventListener.Conflicts.Select(x => x.GetType()), Is.EqualTo(conflictTypes));
 
 			eventListener.AssertExpectedChangesCount(expectedChangesCount);
+			Assert.That(expectedChangesCount, Is.EqualTo(changeTypes.Count),
+				"Test setup error: expected changes and the count of expected change types don't match");
 			Assert.That(eventListener.Changes.Select(x => x.GetType()), Is.EqualTo(changeTypes));
 
 			resultingConflicts = eventListener.Conflicts;

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
@@ -167,5 +167,101 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Common
 				0, new List<Type>(),
 				2, new List<Type> { typeof(XmlAdditionChangeReport), typeof(XmlAdditionChangeReport) });
 		}
+
+		[Test]
+		public void PreMerger_NoConflictsWhenBothChangeToFalse()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string theirsAddsEn = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='false'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string oursAddsFr = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems projectSharing='false'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, oursAddsFr,
+				_commonFile, commonAncestor,
+				_theirFile, theirsAddsEn,
+				new List<string>
+				{
+					"ProjectLexiconSettings/WritingSystems[@addToSldr='false' and @projectSharing='false']"
+				}, null,
+				0, new List<Type>(),
+				0, new List<Type>());
+		}
+
+		[Test]
+		public void PreMerger_NoConflictsIfEachChangeDifferentSetting()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string theirsAddsEn = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='true'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string oursAddsFr = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems projectSharing='true'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, oursAddsFr,
+				_commonFile, commonAncestor,
+				_theirFile, theirsAddsEn,
+				new List<string>
+				{
+					"ProjectLexiconSettings/WritingSystems[@addToSldr='true' and @projectSharing='true']"
+				}, null,
+				0, new List<Type>(),
+				2, new List<Type> { typeof(XmlAttributeChangedReport), typeof(XmlAttributeChangedReport) });
+		}
+
+		[Test]
+		public void PreMerger_CanChangeToFalse()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='true' projectSharing='false'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string theirsAddsEn = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='true' projectSharing='true'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string oursAddsFr = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='false' projectSharing='false'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, oursAddsFr,
+				_commonFile, commonAncestor,
+				_theirFile, theirsAddsEn,
+				new List<string>
+				{
+					"ProjectLexiconSettings/WritingSystems[@addToSldr='false' and @projectSharing='true']"
+				}, null,
+				0, new List<Type>(),
+				2, new List<Type> { typeof(XmlAttributeChangedReport), typeof(XmlAttributeChangedReport) });
+		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Chorus.FileTypeHandlers.xml;
+using LibFLExBridgeChorusPlugin.Infrastructure;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.Progress;
+
+namespace LibFLExBridgeChorusPluginTests.Handling.Common
+{
+	[TestFixture]
+	class ProjectLexiconSettingsTypeHandlerTests : BaseFieldWorksTypeHandlerTests
+	{
+		private TempFile _ourFile;
+		private TempFile _theirFile;
+		private TempFile _commonFile;
+
+		[SetUp]
+		public override void TestSetup()
+		{
+			base.TestSetup();
+			FieldWorksTestServices.SetupTempFilesWithExtension("." + FlexBridgeConstants.ProjectLexiconSettingsExtension, out _ourFile, out _commonFile, out _theirFile);
+		}
+
+		[TearDown]
+		public override void TestTearDown()
+		{
+			base.TestTearDown();
+			FieldWorksTestServices.RemoveTempFiles(ref _ourFile, ref _commonFile, ref _theirFile);
+		}
+
+		[Test]
+		public void DescribeInitialContentsShouldHaveAddedForLabel()
+		{
+			var initialContents = FileHandler.DescribeInitialContents(null, null).ToList();
+			Assert.AreEqual(1, initialContents.Count);
+			var onlyOne = initialContents.First();
+			Assert.AreEqual("Added", onlyOne.ActionLabel);
+		}
+
+		[Test]
+		public void ExtensionOfKnownFileTypesShouldBeStyle()
+		{
+			var extensions = FileHandler.GetExtensionsOfKnownTextFileTypes();
+			Assert.IsTrue(extensions.Contains(FlexBridgeConstants.ProjectLexiconSettingsExtension),
+				$"No handler found for {FlexBridgeConstants.ProjectLexiconSettingsExtension} files.");
+		}
+
+		[Test]
+		public void ShouldBeAbleToValidateIncorrectFormatFileIfFilenameIsRight()
+		{
+			using (var tempModelVersionFile = new TempFile("<classdata />"))
+			{
+				var newpath = Path.ChangeExtension(tempModelVersionFile.Path, FlexBridgeConstants.ProjectLexiconSettingsExtension);
+				File.Copy(tempModelVersionFile.Path, newpath, true);
+				Assert.IsTrue(FileHandler.CanValidateFile(newpath));
+				File.Delete(newpath);
+			}
+		}
+
+		[Test]
+		public void ShouldBeAbleToDoAllCanOperations()
+		{
+			const string data =
+				@"<?xml version='1.0' encoding='utf-8'?><ProjectLexiconSettings/>";
+
+			File.WriteAllText(_ourFile.Path, data);
+			Assert.IsTrue(FileHandler.CanValidateFile(_ourFile.Path));
+			Assert.IsTrue(FileHandler.CanDiffFile(_ourFile.Path));
+			Assert.IsTrue(FileHandler.CanMergeFile(_ourFile.Path));
+			Assert.IsTrue(FileHandler.CanPresentFile(_ourFile.Path));
+		}
+
+		[Test]
+		public void ShouldNotBeAbleToValidateBadFile()
+		{
+			const string data = "<?xml version='1.0' encoding='utf-8'?><classdata />";
+
+			File.WriteAllText(_ourFile.Path, data);
+			Assert.IsNotNull(FileHandler.ValidateFile(_ourFile.Path, new NullProgress()));
+		}
+
+		[Test]
+		public void ShouldNotBeAbleToValidateFileWithDuplicateWsIds()
+		{
+			const string data = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+<WritingSystem id='en'/>
+<WritingSystem id='en'/>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			File.WriteAllText(_ourFile.Path, data);
+			StringAssert.StartsWith("Duplicate", FileHandler.ValidateFile(_ourFile.Path, new NullProgress()));
+		}
+
+		[Test]
+		public void SampleMergeWithNoConflicts()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+<WritingSystem id='en'>
+<Abbreviation>En</Abbreviation>
+<LanguageName>Bad English</LanguageName>
+</WritingSystem>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			var ourContent = commonAncestor.Replace("Bad ", "");
+			const string theirContent = commonAncestor;
+
+			var results = FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, ourContent,
+				_commonFile, commonAncestor,
+				_theirFile, theirContent,
+				null, null,
+				0, new List<Type>(),
+				1, new List<Type> { typeof(XmlChangedRecordReport) });
+			Assert.IsTrue(results.Contains(">English<"));
+		}
+
+		[Test]
+		public void TwoDifferentAdditionsNoConflict()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string theirsAddsEn = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+<WritingSystem id='en'>
+<Abbreviation>En</Abbreviation>
+<LanguageName>Bad English</LanguageName>
+</WritingSystem>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string oursAddsFr = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+<WritingSystem id='fr'>
+<Abbreviation>Fr</Abbreviation>
+<LanguageName>French</LanguageName>
+</WritingSystem>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, oursAddsFr,
+				_commonFile, commonAncestor,
+				_theirFile, theirsAddsEn,
+				new List<string>
+				{
+					"ProjectLexiconSettings/WritingSystems/WritingSystem[@id='en']",
+					"ProjectLexiconSettings/WritingSystems/WritingSystem[@id='fr']"
+				}, null,
+				0, new List<Type>(),
+				2, new List<Type> { typeof(XmlAdditionChangeReport), typeof(XmlAdditionChangeReport) });
+		}
+	}
+}

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/Common/ProjectLexiconSettingsTypeHandlerTests.cs
@@ -263,5 +263,37 @@ namespace LibFLExBridgeChorusPluginTests.Handling.Common
 				0, new List<Type>(),
 				2, new List<Type> { typeof(XmlAttributeChangedReport), typeof(XmlAttributeChangedReport) });
 		}
+
+		[Test]
+		public void PreMerger_TheySetToDefaultWeSetToTrue()
+		{
+			const string commonAncestor = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string theirsAddsEn = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='false'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+			const string oursAddsFr = @"<?xml version='1.0' encoding='utf-8'?>
+<ProjectLexiconSettings>
+<WritingSystems addToSldr='true'>
+</WritingSystems>
+</ProjectLexiconSettings>";
+
+			FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, oursAddsFr,
+				_commonFile, commonAncestor,
+				_theirFile, theirsAddsEn,
+				new List<string>
+				{
+					"ProjectLexiconSettings/WritingSystems[@addToSldr='true']"
+				}, null,
+				0, new List<Type>(),
+				1, new List<Type> { typeof(XmlAttributeChangedReport) });
+		}
 	}
 }

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="DomainServices\CmObjectNestingServiceTests.cs" />
     <Compile Include="DomainServices\CmObjectValidatorTests.cs" />
     <Compile Include="Handling\BaseFieldWorksTypeHandlerTests.cs" />
+    <Compile Include="Handling\Common\ProjectLexiconSettingsTypeHandlerTests.cs" />
     <Compile Include="Handling\DateTimeMergingTests.cs" />
     <Compile Include="Handling\FieldWorksGenericHtmlGeneratorTests.cs" />
     <Compile Include="Handling\FieldWorksObjectContextGeneratorHtmlTests.cs" />

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
@@ -13,7 +13,6 @@ using Chorus.sync;
 using L10NSharp;
 using LibTriboroughBridgeChorusPlugin;
 using SIL.IO;
-using SIL.PlatformUtilities;
 using SIL.Reporting;
 using TriboroughBridge_ChorusPlugin.Properties;
 


### PR DESCRIPTION
* Handle .plsx and .ulsx files
* Copy settings files to and from a Cached folder during S/R
* Configure the repo to include the Cached folder instead of the
  plain folders

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/247)
<!-- Reviewable:end -->
