### PR TITLE
Only copy settings directories that actually exist

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
@@ -180,26 +180,35 @@ namespace LibFLExBridgeChorusPlugin.Contexts
 		{
 			progress.WriteMessage("Copying settings files...");
 			// copy the dictionary configuration files into the .hg included repo
-			if (writeVerbose)
-			{
-				progress.WriteMessage("Copying dictionary configuration settings.");
-			}
 			var dictionaryConfigFolder = Path.Combine(pathRoot, "ConfigurationSettings");
-			DirectoryHelper.Copy(dictionaryConfigFolder, Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings"), true);
+			if (Directory.Exists(dictionaryConfigFolder))
+			{
+				if (writeVerbose)
+				{
+					progress.WriteMessage("Copying dictionary configuration settings.");
+				}
+				DirectoryHelper.Copy(dictionaryConfigFolder, Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings"), true);
+			}
 			// copy the lexicon settings files into the.hg included repo
-			if (writeVerbose)
-			{
-				progress.WriteMessage("Copying shared lexicon settings.");
-			}
 			var sharedSettingsFolder = Path.Combine(pathRoot, "SharedSettings");
-			DirectoryHelper.Copy(sharedSettingsFolder, Path.Combine(pathRoot, "CachedSettings", "SharedSettings"), true);
-			// copy the writing system files into the .hg included repo
-			if (writeVerbose)
+			if (Directory.Exists(sharedSettingsFolder))
 			{
-				progress.WriteMessage("Copying writing systems.");
+				if (writeVerbose)
+				{
+					progress.WriteMessage("Copying shared lexicon settings.");
+				}
+				DirectoryHelper.Copy(sharedSettingsFolder, Path.Combine(pathRoot, "CachedSettings", "SharedSettings"), true);
 			}
+			// copy the writing system files into the .hg included repo
 			var wsFolder = Path.Combine(pathRoot, "WritingSystemStore");
-			DirectoryHelper.Copy(wsFolder, Path.Combine(pathRoot, "CachedSettings", "WritingSystemStore"), true);
+			if (Directory.Exists(wsFolder))
+			{
+				if (writeVerbose)
+				{
+					progress.WriteMessage("Copying writing systems.");
+				}
+				DirectoryHelper.Copy(wsFolder, Path.Combine(pathRoot, "CachedSettings", "WritingSystemStore"), true);
+			}
 		}
 
 		private static void CopySupportingSettingsFilesIntoProjectFolder(IProgress progress, bool writeVerbose, string pathRoot)


### PR DESCRIPTION
Some projects are missing the `ConfigurationSettings` folder, which causes the `DirectoryHelper.Copy` call to fail because the source folder doesn't exist. (`DirectoryHelper.Copy` will create a *destination* folder if it doesn't exist, but it throws an exception if the *source* folder doesn't exist.) If the project doesn't have a settings folder, there's no need to copy it into the cache. https://github.com/sillsdev/flexbridge/commit/f5f45ae1d5aa290b5b99148f8e7a4a97ce7667a2 (which was an extension to https://github.com/sillsdev/flexbridge/pull/247) already makes this change in the part of the code that copies settings folders out of the cache into the project, but didn't do anything for the project->cache direction. It turns out that the project->cache direction is needed too: while doing Send/Receive on one of my test projects on Language Forge, I encountered the following exception:

```plaintext
Error:Sync failure: System.IO.DirectoryNotFoundException: Could not find a part of the path '/var/lib/languageforge/lexicon/sendreceive/webwork/test-rmunn-fr01/ConfigurationSettings'.
  at System.IO.__Error.WinIOError (System.Int32 errorCode, System.String maybeFullPath) [0x00207] in /build/mono5-sil-5.16.0.179/mcs/class/referencesource/mscorlib/system/io/__error.cs:188 
  at System.IO.FileSystemEnumerableIterator`1[TSource].HandleError (System.Int32 hr, System.String path) [0x00006] in <c5a54dbe91cb4981b725403e1a171987>:0 
  at System.IO.FileSystemEnumerableIterator`1[TSource].CommonInit () [0x00054] in <c5a54dbe91cb4981b725403e1a171987>:0 
  at System.IO.FileSystemEnumerableIterator`1[TSource]..ctor (System.String path, System.String originalUserPath, System.String searchPattern, System.IO.SearchOption searchOption, System.IO.SearchResultHandler`1[TSource] resultHandler, System.Boolean checkHost) [0x000
  at System.IO.FileSystemEnumerableFactory.CreateFileNameIterator (System.String path, System.String originalUserPath, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) 
  at System.IO.Directory.InternalGetFileDirectoryNames (System.String path, System.String userPathOriginal, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) [0x00000] i
  at System.IO.Directory.InternalGetFiles (System.String path, System.String searchPattern, System.IO.SearchOption searchOption) [0x00000] in /build/mono5-sil-5.16.0.179/mcs/class/referencesource/mscorlib/system/io/directory.cs:651 
  at System.IO.Directory.GetFiles (System.String path) [0x0000e] in /build/mono5-sil-5.16.0.179/mcs/class/referencesource/mscorlib/system/io/directory.cs:604 
  at SIL.IO.DirectoryHelper.Copy (System.String sourcePath, System.String destinationPath, System.Boolean overwrite) [0x00016] in /var/lib/TeamCity/agent/work/a868e9f1d5fee9d4/SIL.Core/IO/DirectoryHelper.cs:19 
  at LibFLExBridgeChorusPlugin.Contexts.BaseDomainServices.CopySupportingSettingsFilesIntoRepo (SIL.Progress.IProgress progress, System.Boolean writeVerbose, System.String pathRoot) [0x0002f] in /var/lib/TeamCity/agent/work/911b4d93687d524/src/LibFLExBridge-ChorusPlug
  at LibFLExBridgeChorusPlugin.Contexts.BaseDomainServices.PushHumptyOffTheWall (SIL.Progress.IProgress progress, System.Boolean writeVerbose, System.String pathRoot, System.Collections.Generic.IDictionary`2[TKey,TValue] wellUsedElements, System.Collections.Generic.Di
  at LibFLExBridgeChorusPlugin.DomainServices.FLExProjectSplitter.PushHumptyOffTheWall (SIL.Progress.IProgress progress, System.Boolean writeVerbose, System.String mainFilePathname) [0x00063] in /var/lib/TeamCity/agent/work/911b4d93687d524/src/LibFLExBridge-ChorusPlug
  at LibFLExBridgeChorusPlugin.Infrastructure.FlexBridgeSynchronizerAdjunct.PrepareForInitialCommit (SIL.Progress.IProgress progress) [0x00023] in /var/lib/TeamCity/agent/work/911b4d93687d524/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeSynchronizerAdjunct.
  at Chorus.sync.Synchronizer.Commit (Chorus.sync.SyncOptions options) [0x0001b] in <84604d77340f4bb7a7a582210cf81f94>:0 
  at Chorus.sync.Synchronizer.SyncNow (Chorus.sync.SyncOptions options) [0x0006d] in <84604d77340f4bb7a7a582210cf81f94>:0
```

I investigated and found that there were several projects on Language Forge that would trigger this problem because they don't contain a `ConfigurationSettings` folder (it's not just test projects that will trigger this problem). Names of real projects that need this change available at https://docs.google.com/document/d/18UjwcYrnd3ExCXcs4sM4xyvXCO3XTUtUyoQqAcTPXmo/ (private document so we don't expose user data). There are also *many* projects on Language Forge that contain a `ConfigurationSettings` folder but not a `SharedSettings` folder, which would also trigger this exception.

This PR does not yet contain unit tests because I'm trying to fix a different, more urgent, problem right now. But it's essentially the same fix as https://github.com/sillsdev/flexbridge/commit/f5f45ae1d5aa290b5b99148f8e7a4a97ce7667a2 so I believe it should work. If unit tests are needed, I'll come back to this PR once the other problem I'm working on is solved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/250)
<!-- Reviewable:end -->
