### PR TITLE
Or depend on python2, for Ubuntu 20.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ install:
 	/usr/bin/install -m644 lib/common/chorusHubIcon.png $(DESTDIR)/usr/share/pixmaps
 	/usr/bin/install -d $(DESTDIR)/usr/share/applications
 	/usr/bin/install -m644 lib/common/fieldworks-chorushub.desktop $(DESTDIR)/usr/share/applications
+	# Create /usr/bin/python while still needed by included python scripts that request 'python', not 'python2'.
+	(. /etc/os-release; [[ $UBUNTU_CODENAME != focal ]] || ln -s python2 $(DESTDIR)/usr/bin/python )
 	# remove unwanted stuff
 	/bin/rm -f $(DESTDIR)/usr/lib/flexbridge/FwdataTestApp.*
 	/bin/rm -f $(DESTDIR)/usr/lib/flexbridge/*.TestUtilities.*

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Depends: ${misc:Depends}, ${cli:Depends},
  mono4-sil | mono5-sil,
  libgdiplus4-sil | libgdiplus5-sil,
  fieldworks-applications (>= 9.0),
- python (>= 2.7), python (<< 2.8),
+ python2 | python (>= 2.7),
  unzip,
  adduser (>= 3.11)
 Description: Allow multiple FieldWorks users to collaborate remotely


### PR DESCRIPTION
Putting /usr/bin/python into the focal package may introduce conflicts
or other problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/259)
<!-- Reviewable:end -->
