### PR TITLE
Add to FlexBridge a version number (LT-20019)

### DIFF
--- a/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/ObtainProjectStrategyFlex.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/ObtainProjectStrategyFlex.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;
@@ -31,7 +31,8 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 		private static void UpdateToTheCorrectBranchHeadIfPossible(Dictionary<string, string> commandLineArgs,
 			ActualCloneResult cloneResult, string cloneLocation)
 		{
-			if (!UpdateBranchHelper.UpdateToTheCorrectBranchHeadIfPossible(new FlexUpdateBranchHelperStrategy(), commandLineArgs["-fwmodel"], cloneResult, cloneLocation))
+			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + commandLineArgs["-fwmodel"];
+			if (!UpdateBranchHelper.UpdateToTheCorrectBranchHeadIfPossible(new FlexUpdateBranchHelperStrategy(), desiredBranchName, cloneResult, cloneLocation))
 			{
                 if (string.IsNullOrEmpty(cloneResult.Message))
                     cloneResult.Message = CommonResources.kFlexUpdateRequired;

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -72,8 +72,40 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 		internal const string RtTag = "rt";
 
 		// Model Version
+		// An extension for a file that stores {"modelversion":<unit that is the FW model version>}
 		internal const string ModelVersion = "ModelVersion";
+		// The full name of that file
 		internal const string ModelVersionFilename = "FLExProject." + ModelVersion;
+
+		// A value that specifies a version of FlexBridge that affects the data written to the
+		// repo, but not the FieldWorks model version. This is part of the branch name, so for
+		// example a version of FlexBridge that is looking for data on branch 7000072 or 7500001.7000072 will not
+		// try to read data on branch 7500002.7000072, even though (if it could PutHumptyTogetherAgain)
+		// its caller would be able to handle 700072 model data. This allows us to change how
+		// FlexBridge handles the data without changing the data model version (which affects other
+		// products and is becoming increasingly expensive to change).
+		// Note that send/receive never tries to handle data on other branches; it only merges with
+		// data on its own branch (though warning if there are new commits on other branches).
+		// Data migration only happens when a new version of FLEx (and FlexBridge) is installed
+		// on a computer that has the data needing migration, and upgrades and does a send/receive;
+		// or when making a new clone of the project using a newer version of FLEx.
+		// Because of this clone-and-upgrade possibility, FlexBridge must be able to
+		// PutHumptyTogetherAgain for both old data models and old Humpty strategies.
+		// Branch names are formed by putting a dot between the FlexBridgeDataVersion and the
+		// Flex Model Version. To avoid crashing versions of FLEx that work with data models
+		// before 700072, the result must parse as a float. To prevent older versions of FlexBridge
+		// from trying to clone data that is too new for them, the float must be larger than
+		// the largest model version before we introduced this new system, 7000072.
+		// This is achieved by putting the FlexBridgeDataVersion before the model version
+		// and making it start with 750000.
+		// Note: we would have preferred to put the FlexBridgeDataVersion second, giving
+		// numbers like 7000072.02. However, we ran out of significance in Float;
+		// float.Parse("7000072.2") is equal to float.Parse("7000072") which means old
+		// versions of FlexBridge would not detect that 7000072.2 is too new for them
+		// to clone. To allow new versions of FLEx to notice that 7500002.7000073 is larger
+		// than 7500002.7000072, we changed float.Parse() to double.Parse(); but we can't
+		// change the old versions.
+		internal const string FlexBridgeDataVersion = "7500002";
 
 		// Custom Properties
 		internal const string AdditionalFieldsTag = "AdditionalFields";

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeSynchronizerAdjunct.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeSynchronizerAdjunct.cs
@@ -143,15 +143,13 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 		}
 
 		/// <summary>
-		/// Get the data model version number of the current fwdata file.
+		/// Get the branch name that should be used to Send/Receive the current project, made up of the
+		/// model version number of the current fwdata file plus the FlexBridgeDataVersion.
+		/// See the comments on FlexBridgeDataVersion for various constraints on how we come up with this.
+		/// (Note that this cannot, of course, be used in the 'obtain' command, which instead relies on the -fwmodel
+		/// command line argument.)
 		/// </summary>
-		public string BranchName
-		{
-			get
-			{
-				return FieldWorksProjectServices.GetVersionNumber(_fwdataPathname);
-			}
-		}
+		public string BranchName => FlexBridgeConstants.FlexBridgeDataVersion + "." + FieldWorksProjectServices.GetVersionNumber(_fwdataPathname);
 
 		/// <summary>
 		/// Gets a value telling if the adjunct processed anything.

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-16 SIL International
+// Copyright (c) 2015-16 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using LibTriboroughBridgeChorusPlugin.Infrastructure;
@@ -14,12 +14,16 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 
 		#region IUpdateBranchHelperStrategy impl
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
+		// Note that, after Flex9.0.7/FlexBridge3.1, this is actually a two part number, where the whole
+		// number part is the FlexBridgeDataVersion, and the fraction is the actual FLEx
+		// model number. For example, the current code returns 7500002.7000072, where the
+		// number after the decimal is actually the FLEx model version.
+		double IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
 		{
-			return uint.Parse(branchName);
+			return double.Parse(branchName);
 		}
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
+		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
 		{
 			var modelVersion = AsIUpdateBranchHelperStrategy.GetFullModelVersion(cloneLocation);
 			return string.IsNullOrEmpty(modelVersion)

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 {
 	internal interface IUpdateBranchHelperStrategy
 	{
-		float GetModelVersionFromBranchName(string branchName);
-		float GetModelVersionFromClone(string cloneLocation);
+		double GetModelVersionFromBranchName(string branchName);
+		double GetModelVersionFromClone(string cloneLocation);
 		string GetFullModelVersion(string cloneLocation);
 	}
 }

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-2016 SIL International
+// Copyright (c) 2015-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -48,7 +48,7 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 				var gonerKeys = new HashSet<string>();
 				foreach (var headKvp in allHeads)
 				{
-					float currentVersion;
+					double currentVersion;
 					if (headKvp.Key == LibTriboroughBridgeSharedConstants.Default)
 					{
 						repo.Update(headKvp.Value.Number.LocalRevisionNumber);
@@ -104,7 +104,9 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 				}
 
 				// Now. get to the real work.
-				var sortedRevisions = new SortedList<float, Revision>();
+				// Don't be tempted to use 'float' here. We really need the precision of double to tell that e.g.
+				// 7500002.7000073 is greater than 7500002.7000072
+				var sortedRevisions = new SortedList<double, Revision>();
 				foreach (var kvp in allHeads)
 				{
 					sortedRevisions.Add(updateBranchHelperStrategy.GetModelVersionFromBranchName(kvp.Key), kvp.Value);

--- a/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
+++ b/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015-2018 SIL International
+// Copyright (c) 2015-2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -12,26 +12,26 @@ namespace SIL.LiftBridge.Infrastructure
 {
 	internal sealed class UpdateBranchHelperLift : IUpdateBranchHelperStrategy
 	{
-		internal static float GetLiftVersionNumber(string repoLocation)
+		internal static double GetLiftVersionNumber(string repoLocation)
 		{
 			var firstLiftFile = FileAndDirectoryServices.GetPathToFirstLiftFile(repoLocation);
 			if (string.IsNullOrEmpty(firstLiftFile))
-				return float.MaxValue;
+				return double.MaxValue;
 
 			using (var reader = XmlReader.Create(firstLiftFile, CanonicalXmlSettings.CreateXmlReaderSettings()))
 			{
 				reader.MoveToContent();
 				reader.MoveToAttribute("version");
-				return float.Parse(reader.Value, NumberFormatInfo.InvariantInfo);
+				return double.Parse(reader.Value, NumberFormatInfo.InvariantInfo);
 			}
 		}
 
-		public float GetModelVersionFromBranchName(string branchName)
+		public double GetModelVersionFromBranchName(string branchName)
 		{
-			return float.Parse(branchName.Replace("LIFT", null).Split('_')[0], NumberFormatInfo.InvariantInfo);
+			return double.Parse(branchName.Replace("LIFT", null).Split('_')[0], NumberFormatInfo.InvariantInfo);
 		}
 
-		public float GetModelVersionFromClone(string cloneLocation)
+		public double GetModelVersionFromClone(string cloneLocation)
 		{
 			return GetLiftVersionNumber(cloneLocation);
 		}

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -240,6 +240,9 @@ namespace TriboroughBridge_ChorusPlugin
 					throw new CommandLineException("-f", "missing 'FixFwData.exe'");
 			}
 
+			// I believe this is actually only used by the "obtain" and possibly "obtain_lift" actions.
+			// Send/receive, at least, does not use it, but obtains model version data from the fwdata file itself.
+			// (JohnT, March 23, 2020).
 			if (!commandLineArgs.ContainsKey(fwmodel) || String.IsNullOrEmpty(commandLineArgs[fwmodel]))
 				throw new CommandLineException("-fwmodel", "is missing");
 			var fwmodelOption = uint.Parse(commandLineArgs[fwmodel]);


### PR DESCRIPTION
The branch name that FlexBridge uses will now be made up of ModelVersion.FlexBridgeDataVersion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/263)
<!-- Reviewable:end -->
