### PR TITLE
Updated version to 3.1.3

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 3.1.2
+next-version: 3.1.3
 increment: Patch
 assembly-versioning-scheme: MajorMinorPatchTag
 branches:
@@ -8,7 +8,7 @@ branches:
     regex: (origin/)?master
     is-mainline: true
   develop:
-    tag: unstable
+    tag: beta
     regex: (origin/)?develop
     is-mainline: true
   lfmerge:

--- a/build/WixPatchableInstaller.targets
+++ b/build/WixPatchableInstaller.targets
@@ -12,7 +12,7 @@
 	<!-- base build must get its own unique third number (minor version) in the version number sequence. -->
 	<!-- FLEx Bridge 3.1.2.X -->
 	<PropertyGroup>
-		<ProductIdGuid>984F61B7-5A78-49C3-99DF-87A0590E3838</ProductIdGuid>
+		<ProductIdGuid>5FB44ADA-56B6-4F62-8EC8-46C8AE2D8DD6</ProductIdGuid>
 	</PropertyGroup>
 
 	<!-- UPGRADE CODE GUID definition : This value must be the same for every version of this product. -->

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flexbridge (3.1.3) UNRELEASED; urgency=low
+
+  * Chorus updated with bugfix for LT-20019
+
+ -- Jason Naylor <jason_naylor@sil.org>  Thu, 02 Apr 2020 20:57:43 -0500
+
 flexbridge (3.1.2) UNRELEASED; urgency=low
 
   * Chorus updated with bugfix for losing Notes bug

--- a/src/Installer/Beta.htm
+++ b/src/Installer/Beta.htm
@@ -11,6 +11,10 @@
     </p>
     <h4>Release Notes</h4>
     <div class="releasenotes">
+      <h2 xmlns="">3.1.3 2020-04-02</h2>
+      <ul xmlns="">
+        <li>Chorus updated with bugfix for LT-20019</li>
+      </ul>
       <h2 xmlns="">3.1.2 2020-03-19</h2>
       <ul xmlns="">
         <li>Chorus updated with bugfix for losing Notes bug</li>

--- a/src/Installer/ReleaseNotes.md
+++ b/src/Installer/ReleaseNotes.md
@@ -1,3 +1,7 @@
+## 3.1.3 2020-04-02
+
+* Chorus updated with bugfix for LT-20019
+
 ## 3.1.2 2020-03-19
 
 * Chorus updated with bugfix for losing Notes bug


### PR DESCRIPTION
* Include Chorus bugfix for LT-20019
* Change 'unstable' tag to 'beta' for develop
  branch builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/264)
<!-- Reviewable:end -->
