### PR TITLE
Enhance VSCode building and launching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,36 +1,46 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Launch",
-            "type": "mono",
-            "request": "launch",
-            "program": "${workspaceRoot}/output/DebugMono/FLExBridge.exe",
-            "args": [
-                "-u", "${env:USER}",
-                "-p", "${env:HOME}/fwrepo/fw/DistFiles/Projects",
-                "-v", "obtain",
-                "-projDir", "${env:HOME}/fwrepo/fw/DistFiles/Projects",
-                "-fwAppsDir","${env:HOME}/fwrepo/fw/Output_x86_64/Debug",
-                "-fwmodel", "7000072",
-                "-liftmodel", "0.13_ldml3",
-                "-locale", "en",
-                "-pipeID", "SendReceive${env:HOME}/fwrepo/fw/DistFiles/Projectsobtain"
-            ],
-            "env": {
-                "MONO_ENVIRON": "${env:HOME}/fwrepo/flexbridge/environ"
-            },
-            "cwd": "${workspaceRoot}"
-        },
-        {
-            "name": "Attach",
-            "type": "mono",
-            "request": "attach",
-            "address": "localhost",
-            "port": 55555
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "mono",
+      "request": "launch",
+      "program": "${workspaceRoot}/output/DebugMono/FLExBridge.exe",
+      "args": [
+        "-u", "${env:USER}",
+        "-projDir", "${env:HOME}/fwrepo/fw/DistFiles/Projects",
+        "-fwAppsDir", "${env:HOME}/fwrepo/fw/Output/Debug",
+        "-fwmodel", "7000072",
+        "-liftmodel", "0.13",
+        "-locale", "en",
+        // Change these arguments to launch and debug different areas.
+        // Launching FB via FW and running `ps faxww | grep FLExBridge` will
+        // reveal what setting for -p, -v, -f, and -pipeID to change
+        // these to. Then modify FW by commenting out Process.Start in
+        // FLexBridgeHelper.cs.
+        // -p could instead be .../Projects/foo/foo.fwdata
+        "-p", "${env:HOME}/fwrepo/fw/DistFiles/Projects",
+        "-v", "obtain", // eg: obtain, send_receive
+        // "-f", "${env:HOME}/fwrepo/fw/Output/Debug/FixFwData.exe",
+        // -pipeId could instead be .../Projects/foo/foo.fwdatasend_receive
+        "-pipeID", "SendReceive${env:HOME}/fwrepo/fw/DistFiles/Projectsobtain"
+      ],
+      "env": {
+        // When launching, use this mono.
+        "PATH": "/opt/mono5-sil/bin:${env:PATH}",
+        "MONO_ENVIRON": "${env:HOME}/fwrepo/flexbridge/environ"
+      },
+      "cwd": "${workspaceRoot}"
+    },
+    {
+      "name": "Attach",
+      "type": "mono",
+      "request": "attach",
+      "address": "localhost",
+      "port": 55555
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    // A quick start at build specifying, which much room for improvement.
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": "make debug_build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [
+        "$msCompile"
+      ]
+    },
+    {
+      "label": "Initial build",
+      "type": "shell",
+      "command": "make debug",
+      "group": "build",
+      "problemMatcher": [
+        "$msCompile"
+      ]
+    },
+  ]
+}


### PR DESCRIPTION
* Set PATH, to use a specific mono when running FB.
* Added documentation for launching in various ways. An improvement
  would be to have different configurations launch FB in different
  modes, but the project would still need manually specified in the
  arguments.
* Add build tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/267)
<!-- Reviewable:end -->
