### PR TITLE
Fix L10nSharp load problem

### DIFF
--- a/FLExBridge.sln.DotSettings
+++ b/FLExBridge.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Triborough/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/UpdateDependencies.bat
+++ b/UpdateDependencies.bat
@@ -45,8 +45,5 @@ copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\ChorusMerge.pdb output\%BUILD_CONFIG%
 copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\ChorusHub.exe lib\%BUILD_CONFIG%\
 copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\ChorusHub.pdb output\%BUILD_CONFIG%\
 
-copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\Palaso*.dll lib\%BUILD_CONFIG%\
-copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\Palaso*.pdb output\%BUILD_CONFIG%\
-
-copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\SIL.*.dll lib\%BUILD_CONFIG%\
-copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\SIL.*.pdb output\%BUILD_CONFIG%\
+REM copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\SIL.*.dll lib\%BUILD_CONFIG%\
+REM copy /Y %CHORUS_DIR%\output\%BUILD_CONFIG%\SIL.*.pdb output\%BUILD_CONFIG%\

--- a/UpdateDependencies.bat
+++ b/UpdateDependencies.bat
@@ -4,15 +4,19 @@ REM This script assumes that the Chorus and Palaso directories are on the same l
 REM this one, and that the FieldWorks repo is also at the same level.
 REM It copies the needed libraries into the lib folder.
 
-set CHORUS_DIR="..\chorus"
-
-IF NOT EXIST %CHORUS_DIR% GOTO :EOF
-
 IF "%1"=="" (
 	set BUILD_CONFIG="Debug"
 ) ELSE (
 	set BUILD_CONFIG=%1
 )
+
+REM Uncomment these lines if you are working on L10NSharp
+REM copy /Y ..\l10nsharp\output\%BUILD_CONFIG%\L10NSharp.* lib\%BUILD_CONFIG%\
+REM copy /Y ..\l10nsharp\output\%BUILD_CONFIG%\L10NSharp.* output\%BUILD_CONFIG%\
+
+set CHORUS_DIR="..\chorus"
+
+IF NOT EXIST %CHORUS_DIR% GOTO :EOF
 
 pushd %CHORUS_DIR%
 REM Presence of a second argument indicates that the caller has already run vsvars32.bat

--- a/download_dependencies_linux.sh
+++ b/download_dependencies_linux.sh
@@ -99,27 +99,27 @@ cd -
 #     revision: latest.lastSuccessful
 #     paths: {"Autofac.dll"=>"lib/common"}
 #     VCS: https://github.com/sillsdev/chorus.git [master]
-# [5] build: IPC-Precise64 (bt279)
+# [4] build: IPC-Precise64 (bt279)
 #     project: IPC Library
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=bt279
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"IPCFramework.*"=>"lib/ReleaseMono"}
 #     VCS: https://bitbucket.org/smcconnel/ipcframework [develop]
-# [6] build: IPC-Precise64 (bt279)
+# [5] build: IPC-Precise64 (bt279)
 #     project: IPC Library
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=bt279
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"IPCFramework.*"=>"lib/DebugMono"}
 #     VCS: https://bitbucket.org/smcconnel/ipcframework [develop]
-# [7] build: palaso-linux64-master Continuous (Libpalaso_PalasoLinux64masterContinuous)
+# [6] build: palaso-linux64-master Continuous (Libpalaso_PalasoLinux64masterContinuous)
 #     project: libpalaso
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=Libpalaso_PalasoLinux64masterContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"SIL.Core.dll*"=>"lib/ReleaseMono", "SIL.Core.Desktop.dll*"=>"lib/ReleaseMono", "SIL.TestUtilities.dll*"=>"lib/ReleaseMono", "SIL.Windows.Forms.dll*"=>"lib/ReleaseMono", "SIL.Windows.Forms.GeckoBrowserAdapter.dll"=>"lib/ReleaseMono", "SIL.Lift.dll"=>"lib/ReleaseMono", "NDesk.*"=>"lib/ReleaseMono", "debug/SIL.Core.dll*"=>"lib/DebugMono", "debug/SIL.Core.Desktop.dll*"=>"lib/DebugMono", "debug/SIL.TestUtilities.dll*"=>"lib/DebugMono", "debug/SIL.Windows.Forms.dll*"=>"lib/DebugMono", "debug/SIL.Windows.Forms.GeckoBrowserAdapter.dll*"=>"lib/DebugMono", "debug/SIL.Lift.dll*"=>"lib/DebugMono", "debug/NDesk.*"=>"lib/DebugMono"}
-#     VCS: https://github.com/sillsdev/libpalaso.git [master]
+#     paths: {"SIL.Core.dll*"=>"lib/ReleaseMono", "SIL.Core.Desktop.dll*"=>"lib/ReleaseMono", "SIL.TestUtilities.dll*"=>"lib/ReleaseMono", "SIL.Windows.Forms.dll*"=>"lib/ReleaseMono", "SIL.Windows.Forms.GeckoBrowserAdapter.dll"=>"lib/ReleaseMono", "SIL.Lift.dll"=>"lib/ReleaseMono", "L10NSharp.dll"=>"lib/ReleaseMono", "NDesk.*"=>"lib/ReleaseMono", "debug/SIL.Core.dll*"=>"lib/DebugMono", "debug/SIL.Core.Desktop.dll*"=>"lib/DebugMono", "debug/SIL.TestUtilities.dll*"=>"lib/DebugMono", "debug/SIL.Windows.Forms.dll*"=>"lib/DebugMono", "debug/SIL.Windows.Forms.GeckoBrowserAdapter.dll*"=>"lib/DebugMono", "debug/SIL.Lift.dll*"=>"lib/DebugMono", "debug/L10NSharp.dll"=>"lib/DebugMono", "debug/NDesk.*"=>"lib/DebugMono"}
+#     VCS: https://github.com/sillsdev/libpalaso.git [refs/heads/master]
 
 # make sure output directories exist
 mkdir -p ./MercurialExtensions
@@ -172,6 +172,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.Windows.Forms.dll.config ./lib/ReleaseMono/SIL.Windows.Forms.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.Windows.Forms.GeckoBrowserAdapter.dll ./lib/ReleaseMono/SIL.Windows.Forms.GeckoBrowserAdapter.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.Lift.dll ./lib/ReleaseMono/SIL.Lift.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/L10NSharp.dll ./lib/ReleaseMono/L10NSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/NDesk.DBus.dll ./lib/ReleaseMono/NDesk.DBus.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/NDesk.DBus.dll.config ./lib/ReleaseMono/NDesk.DBus.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/SIL.Core.dll ./lib/DebugMono/SIL.Core.dll
@@ -181,6 +182,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/SIL.Windows.Forms.dll.config ./lib/DebugMono/SIL.Windows.Forms.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/SIL.Windows.Forms.GeckoBrowserAdapter.dll ./lib/DebugMono/SIL.Windows.Forms.GeckoBrowserAdapter.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/SIL.Lift.dll ./lib/DebugMono/SIL.Lift.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/L10NSharp.dll ./lib/DebugMono/L10NSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/NDesk.DBus.dll ./lib/DebugMono/NDesk.DBus.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/debug/NDesk.DBus.dll.config ./lib/DebugMono/NDesk.DBus.dll.config
 # End of script

--- a/download_dependencies_windows.sh
+++ b/download_dependencies_windows.sh
@@ -92,27 +92,27 @@ cd -
 #     revision: latest.lastSuccessful
 #     paths: {"Chorus.exe"=>"lib/Debug", "LibChorus.dll"=>"lib/Debug", "ChorusMerge.exe"=>"lib/Debug", "Mercurial.zip"=>"lib/Debug", "LibChorus.TestUtilities.dll"=>"lib/Debug", "*.pdb"=>"lib/Debug"}
 #     VCS: https://github.com/sillsdev/chorus.git [master]
-# [4] build: IPC continuous (bt278)
+# [3] build: IPC continuous (bt278)
 #     project: IPC Library
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=bt278
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"IPCFramework.*"=>"lib/Release"}
 #     VCS: https://bitbucket.org/smcconnel/ipcframework [develop]
-# [5] build: IPC continuous (bt278)
+# [4] build: IPC continuous (bt278)
 #     project: IPC Library
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=bt278
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"IPCFramework.*"=>"lib/Debug"}
 #     VCS: https://bitbucket.org/smcconnel/ipcframework [develop]
-# [6] build: palaso-win32-master Continuous (Libpalaso_PalasoWin32masterContinuous)
+# [5] build: palaso-win32-master Continuous (Libpalaso_PalasoWin32masterContinuous)
 #     project: libpalaso
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=Libpalaso_PalasoWin32masterContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"SIL.Core.Desktop.dll"=>"lib/Release", "SIL.Core.Desktop.pdb"=>"lib/Release", "SIL.Core.dll"=>"lib/Release", "SIL.Core.pdb"=>"lib/Release", "SIL.Lift.dll"=>"lib/Release", "SIL.Lift.pdb"=>"lib/Release", "SIL.TestUtilities.dll"=>"lib/Release", "SIL.TestUtilities.pdb"=>"lib/Release", "SIL.Windows.Forms.dll"=>"lib/Release", "SIL.Windows.Forms.pdb"=>"lib/Release", "SIL.WritingSystems.dll"=>"lib/Release", "SIL.WritingSystems.pdb"=>"lib/Release", "debug/SIL.Core.Desktop.dll"=>"lib/Debug", "debug/SIL.Core.Desktop.pdb"=>"lib/Debug", "debug/SIL.Core.dll"=>"lib/Debug", "debug/SIL.Core.pdb"=>"lib/Debug", "debug/SIL.Lift.dll"=>"lib/Debug", "debug/SIL.Lift.pdb"=>"lib/Debug", "debug/SIL.TestUtilities.dll"=>"lib/Debug", "debug/SIL.TestUtilities.pdb"=>"lib/Debug", "debug/SIL.Windows.Forms.dll"=>"lib/Debug", "debug/SIL.Windows.Forms.pdb"=>"lib/Debug", "debug/SIL.WritingSystems.dll"=>"lib/Debug", "debug/SIL.WritingSystems.pdb"=>"lib/Debug" }
-#     VCS: https://github.com/sillsdev/libpalaso.git [master]
+#     paths: {"SIL.Core.Desktop.dll"=>"lib/Release", "SIL.Core.Desktop.pdb"=>"lib/Release", "SIL.Core.dll"=>"lib/Release", "SIL.Core.pdb"=>"lib/Release", "SIL.Lift.dll"=>"lib/Release", "SIL.Lift.pdb"=>"lib/Release", "SIL.TestUtilities.dll"=>"lib/Release", "SIL.TestUtilities.pdb"=>"lib/Release", "SIL.Windows.Forms.dll"=>"lib/Release", "SIL.Windows.Forms.pdb"=>"lib/Release", "SIL.WritingSystems.dll"=>"lib/Release", "SIL.WritingSystems.pdb"=>"lib/Release", "L10NSharp.dll"=>"lib/Release", "L10NSharp.pdb"=>"lib/Release", "debug/SIL.Core.Desktop.dll"=>"lib/Debug", "debug/SIL.Core.Desktop.pdb"=>"lib/Debug", "debug/SIL.Core.dll"=>"lib/Debug", "debug/SIL.Core.pdb"=>"lib/Debug", "debug/SIL.Lift.dll"=>"lib/Debug", "debug/SIL.Lift.pdb"=>"lib/Debug", "debug/SIL.TestUtilities.dll"=>"lib/Debug", "debug/SIL.TestUtilities.pdb"=>"lib/Debug", "debug/SIL.Windows.Forms.dll"=>"lib/Debug", "debug/SIL.Windows.Forms.pdb"=>"lib/Debug", "debug/SIL.WritingSystems.dll"=>"lib/Debug", "debug/SIL.WritingSystems.pdb"=>"lib/Debug", "debug/L10NSharp.dll"=>"lib/Debug", "debug/L10NSharp.pdb"=>"lib/Debug"}
+#     VCS: https://github.com/sillsdev/libpalaso.git [refs/heads/master]
 
 # make sure output directories exist
 mkdir -p ./MercurialExtensions
@@ -175,6 +175,8 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/SIL.Windows.Forms.pdb ./lib/Release/SIL.Windows.Forms.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/SIL.WritingSystems.dll ./lib/Release/SIL.WritingSystems.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/SIL.WritingSystems.pdb ./lib/Release/SIL.WritingSystems.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/L10NSharp.dll ./lib/Release/L10NSharp.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/L10NSharp.pdb ./lib/Release/L10NSharp.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.Core.Desktop.dll ./lib/Debug/SIL.Core.Desktop.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.Core.Desktop.pdb ./lib/Debug/SIL.Core.Desktop.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.Core.dll ./lib/Debug/SIL.Core.dll
@@ -187,4 +189,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.Windows.Forms.pdb ./lib/Debug/SIL.Windows.Forms.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.WritingSystems.dll ./lib/Debug/SIL.WritingSystems.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/SIL.WritingSystems.pdb ./lib/Debug/SIL.WritingSystems.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/L10NSharp.dll ./lib/Debug/L10NSharp.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/latest.lastSuccessful/debug/L10NSharp.pdb ./lib/Debug/L10NSharp.pdb
 # End of script

--- a/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
+++ b/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
@@ -183,16 +183,15 @@
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.1\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
+    </Reference>
     <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\YamlDotNet.5.2.1\lib\net45\YamlDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=0.1.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927">
-      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.0\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/FLEx-ChorusPlugin/packages.config
+++ b/src/FLEx-ChorusPlugin/packages.config
@@ -4,16 +4,16 @@
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />
   <package id="icu.net" version="2.5.4" targetFramework="net461" />
   <package id="Icu4c.Win.Min" version="54.1.31" targetFramework="net40" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
-  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net461" />
   <package id="LibGit2Sharp" version="0.26.0" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="2.0.267" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.1" targetFramework="net461" />
   <package id="YamlDotNet" version="5.2.1" targetFramework="net461" />
 </packages>

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -86,6 +86,10 @@
     <Reference Include="Chorus">
       <HintPath>..\..\lib\Release\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Release\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Release\LibChorus.dll</HintPath>
@@ -106,6 +110,10 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <Reference Include="Chorus">
       <HintPath>..\..\lib\Debug\Chorus.exe</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Debug\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
@@ -128,6 +136,10 @@
     <Reference Include="Chorus">
       <HintPath>..\..\lib\ReleaseMono\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\ReleaseMono\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\ReleaseMono\LibChorus.dll</HintPath>
@@ -149,6 +161,9 @@
     <Reference Include="Chorus">
       <HintPath>..\..\lib\DebugMono\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <HintPath>..\..\lib\DebugMono\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\DebugMono\LibChorus.dll</HintPath>
@@ -167,10 +182,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
-      <HintPath>..\..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="GitTools.Core, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GitTools.Core-alt.1.3.1.2\lib\net461\GitTools.Core.dll</HintPath>
     </Reference>

--- a/src/FLExBridge/packages.config
+++ b/src/FLExBridge/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net461" developmentDependency="true" />

--- a/src/FwdataNester/FwdataTestApp.csproj
+++ b/src/FwdataNester/FwdataTestApp.csproj
@@ -120,9 +120,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=0.1.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927">
-      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.0\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.1\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/FwdataNester/packages.config
+++ b/src/FwdataNester/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
+  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.1" targetFramework="net461" />
 </packages>

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
@@ -1,10 +1,8 @@
-// Copyright (c) 2015-2016 SIL International
+// Copyright (c) 2015-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using SIL.Progress;
 using Chorus.VcsDrivers.Mercurial;
 

--- a/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
+++ b/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
@@ -196,13 +196,12 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=0.1.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927">
-      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.0\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.Serialization.Primitives.4.3.0\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.1\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\YamlDotNet.5.2.1\lib\net45\YamlDotNet.dll</HintPath>

--- a/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
+++ b/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
@@ -178,10 +178,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
-      <HintPath>..\..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="GitTools.Core, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GitTools.Core-alt.1.3.1.2\lib\net461\GitTools.Core.dll</HintPath>
     </Reference>

--- a/src/LiftBridge-ChorusPlugin/packages.config
+++ b/src/LiftBridge-ChorusPlugin/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
   <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />

--- a/src/LiftBridge-ChorusPlugin/packages.config
+++ b/src/LiftBridge-ChorusPlugin/packages.config
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net461" developmentDependency="true" />
@@ -9,5 +8,6 @@
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.1" targetFramework="net461" />
   <package id="YamlDotNet" version="5.2.1" targetFramework="net461" />
 </packages>

--- a/src/RepositoryUtility/RepositoryUtility.csproj
+++ b/src/RepositoryUtility/RepositoryUtility.csproj
@@ -67,6 +67,10 @@
       <ExecutableExtension>.exe</ExecutableExtension>
       <HintPath>..\..\lib\Release\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Release\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Release\LibChorus.dll</HintPath>
@@ -89,6 +93,10 @@
       <SpecificVersion>False</SpecificVersion>
       <ExecutableExtension>.exe</ExecutableExtension>
       <HintPath>..\..\lib\Debug\Chorus.exe</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Debug\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
@@ -113,6 +121,10 @@
       <ExecutableExtension>.exe</ExecutableExtension>
       <HintPath>..\..\lib\ReleaseMono\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\ReleaseMono\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\ReleaseMono\LibChorus.dll</HintPath>
@@ -135,6 +147,9 @@
       <SpecificVersion>False</SpecificVersion>
       <ExecutableExtension>.exe</ExecutableExtension>
       <HintPath>..\..\lib\DebugMono\Chorus.exe</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp">
+      <HintPath>..\..\lib\DebugMono\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <SpecificVersion>False</SpecificVersion>
@@ -168,10 +183,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
-      <HintPath>..\..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="GitTools.Core, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GitTools.Core-alt.1.3.1.2\lib\net461\GitTools.Core.dll</HintPath>
     </Reference>

--- a/src/RepositoryUtility/packages.config
+++ b/src/RepositoryUtility/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net461" developmentDependency="true" />

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.2.0.267\build\net46\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
@@ -185,9 +185,8 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=0.1.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927">
-      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.0\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Vulcan.Uczniowie.HelpProvider, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c5e47f534b8ee927, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Vulcan.Uczniowie.HelpProvider.1.0.1\lib\net461\Vulcan.Uczniowie.HelpProvider.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\YamlDotNet.5.2.1\lib\net45\YamlDotNet.dll</HintPath>

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
@@ -67,6 +67,10 @@
     <Reference Include="IPCFramework">
       <HintPath>..\..\lib\Release\IPCFramework.dll</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Release\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\Release\LibChorus.dll</HintPath>
     </Reference>
@@ -87,6 +91,10 @@
     </Reference>
     <Reference Include="IPCFramework">
       <HintPath>..\..\lib\Debug\IPCFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Debug\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\Debug\LibChorus.dll</HintPath>
@@ -109,6 +117,10 @@
     <Reference Include="IPCFramework">
       <HintPath>..\..\lib\ReleaseMono\IPCFramework.dll</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\ReleaseMono\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\ReleaseMono\LibChorus.dll</HintPath>
     </Reference>
@@ -130,6 +142,9 @@
     <Reference Include="IPCFramework">
       <HintPath>..\..\lib\DebugMono\IPCFramework.dll</HintPath>
     </Reference>
+    <Reference Include="L10NSharp">
+      <HintPath>..\..\lib\DebugMono\L10NSharp.dll</HintPath>
+    </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\DebugMono\LibChorus.dll</HintPath>
     </Reference>
@@ -145,10 +160,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
-      <HintPath>..\..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="GitTools.Core, Version=1.3.1.2, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GitTools.Core-alt.1.3.1.2\lib\net461\GitTools.Core.dll</HintPath>
     </Reference>

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2019 SIL International
+// Copyright (c) 2010-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -21,9 +21,9 @@ namespace TriboroughBridge_ChorusPlugin
 	/// <summary>
 	/// This class holds constants and methods that are relevant to common bridge operations.
 	/// A lot of what it had held earlier, was moved into places like Flex Bridge's SharedConstants class or
-	/// into Lift Bridge's LiftUtilties class, when the stuff was only used by one bridge.
+	/// into Lift Bridge's LiftUtilities class, when the stuff was only used by one bridge.
 	///
-	/// Some of the remaining constants could yet be moved at the cost of having duplciates in each bridge's project.
+	/// Some of the remaining constants could yet be moved at the cost of having duplicates in each bridge's project.
 	/// It may be worth that to be rid of bridge-specific stuff in this project.
 	/// </summary>
 	internal static class TriboroughBridgeUtilities

--- a/src/TriboroughBridge-ChorusPlugin/packages.config
+++ b/src/TriboroughBridge-ChorusPlugin/packages.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
   <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />

--- a/src/TriboroughBridge-ChorusPlugin/packages.config
+++ b/src/TriboroughBridge-ChorusPlugin/packages.config
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.0" targetFramework="net461" />
   <package id="GitTools.Core-alt" version="1.3.1.2" targetFramework="net461" developmentDependency="true" />
   <package id="GitVersionTask.alt" version="4.0.2-alpha-0006" targetFramework="net461" developmentDependency="true" />
   <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net461" developmentDependency="true" />
@@ -9,5 +8,6 @@
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net461" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="Vulcan.Uczniowie.HelpProvider" version="1.0.1" targetFramework="net461" />
   <package id="YamlDotNet" version="5.2.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Download L10NSharp.dll from TeamCity Palaso build.
Because everyone (at least Chorus and FLEx) uses L10NSharp.dll
from Palaso builds, there will be no version conflicts.
(This is what FLEx Bridge builds were already doing on TeamCity.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/271)
<!-- Reviewable:end -->
