### PR TITLE
Handle dotnet-sdk dependency manually

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,6 @@ Build-Depends: debhelper (>= 9.0.0),
  wget,
  unzip,
  ca-certificates,
- dotnet-sdk-2.1,
  git
 Standards-Version: 3.9.6
 Homepage: http://projects.palaso.org/projects/fwbridge

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,18 @@ export XDG_CONFIG_HOME=/tmp/.config
 # Help dotnet tools get installed to and used from $HOME/bin
 export HOME=$(shell mktemp -d)
 
+installDotnetSdk:
+	echo "Installing dotnet sdk 2.1 from tar.gz, so available to releases that don't have a package yet."
+	mkdir -p /usr/local/share/dotnet
+	cd /usr/local/share/dotnet \
+	  && wget https://download.visualstudio.microsoft.com/download/pr/e730fe40-e2ea-42e5-a5d0-f86830d75849/571e5a2f4ebf9f8117878eeaad5cb19b/dotnet-sdk-2.1.805-linux-x64.tar.gz \
+	  && tar xf dotnet-sdk-2.1.805-linux-x64.tar.gz
+	ln -s ../local/share/dotnet/dotnet /usr/local/bin/dotnet
+
 %:
 	dh $@ --with cli
 
 override_dh_clideps:
+
+override_dh_auto_build: installDotnetSdk
+	dh_auto_build


### PR DESCRIPTION
* Since package is not available for focal presently.
* tar is extracted into /usr/local/share/dotnet, with symlink
  from /usr/local/bin/dotnet to /usr/local/share/dotnet/dotnet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/278)
<!-- Reviewable:end -->
