### PR TITLE
Install dotnet sdk from tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,13 @@ clean:
 
 fetch_l10ns:
 	dotnet tool update -g overcrowdin || dotnet tool install -g overcrowdin
-	. ./environ \
-	  && . /etc/profile.d/dotnet-cli-tools-bin-path.sh \
-	  && cd l10n \
-	  && msbuild l10n.proj /t:restore \
-	  && msbuild l10n.proj /t:GetlatestL10ns
+	bash -c '\
+	  . environ \
+	    && export PATH="$$PATH:${HOME}/.dotnet/tools" \
+	    && cd l10n \
+	    && msbuild l10n.proj /t:restore \
+	    && msbuild l10n.proj /t:GetlatestL10ns \
+	'
 
 install: fetch_l10ns
 	/usr/bin/install -d $(DESTDIR)/usr/lib/flexbridge

--- a/debian/rules
+++ b/debian/rules
@@ -5,17 +5,21 @@
 
 # Help nuget
 export XDG_CONFIG_HOME=/tmp/.config
-# Help dotnet tools get installed to and used from $HOME/bin
-export HOME=$(shell mktemp -d)
+# Setting HOME to somewhere writable helps dotnet tools get installed to and used from $HOME/.dotnet/tools
+# Setting HOME to something constant helps install dotnet-sdk from tar once and keep it in PATH.
+export HOME:=/var/tmp/buildhome
+export PATH:=$(PATH):$(HOME)/.local/bin
+export DOTNET_ROOT:=${HOME}/.local/share/dotnet
 
 installDotnetSdk:
 	echo "Installing dotnet sdk 2.1 from tar.gz, so available to releases that don't have a package yet."
-	mkdir -p /usr/local/share/dotnet
-	cd /usr/local/share/dotnet \
-	  && wget https://download.visualstudio.microsoft.com/download/pr/e730fe40-e2ea-42e5-a5d0-f86830d75849/571e5a2f4ebf9f8117878eeaad5cb19b/dotnet-sdk-2.1.805-linux-x64.tar.gz \
-	  && tar xf dotnet-sdk-2.1.805-linux-x64.tar.gz
-	ln -s ../local/share/dotnet/dotnet /usr/local/bin/dotnet
-
+	bash -c '\
+		mkdir -p "${HOME}/.local/share/dotnet" "${HOME}/.local/bin" \
+			&& cd "${HOME}/.local/share/dotnet" \
+			&& wget https://download.visualstudio.microsoft.com/download/pr/e730fe40-e2ea-42e5-a5d0-f86830d75849/571e5a2f4ebf9f8117878eeaad5cb19b/dotnet-sdk-2.1.805-linux-x64.tar.gz \
+			&& tar xf dotnet-sdk-2.1.805-linux-x64.tar.gz \
+			&& ln -s ../share/dotnet/dotnet "${HOME}/.local/bin/dotnet" \
+	'
 %:
 	dh $@ --with cli
 


### PR DESCRIPTION
* Since focal package is not available yet.
* Can't write to /usr or seemingly anywhere but /tmp, /var/tmp, and
  /build during sbuild. Install to
  /var/tmp/buildhome/.local/share/dotnet, and access via
  /var/tmp/buildhome/.local/bin being in the path.
* The dotnet sdk tar didn't seem to ship with a
  dotnet-cli-tools-bin-path.sh file. Just manually appending
  HOME/.dotnet/tools to path to find overcrowdin, in Makefile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/280)
<!-- Reviewable:end -->
