### PR TITLE
Fix crash using FB in Swedish locale

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-16 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System.Globalization;
 using LibTriboroughBridgeChorusPlugin.Infrastructure;
 
 namespace LibFLExBridgeChorusPlugin.Infrastructure
@@ -20,7 +21,7 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 		// number after the decimal is actually the FLEx model version.
 		double IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
 		{
-			return double.Parse(branchName);
+			return double.Parse(branchName, NumberFormatInfo.InvariantInfo);
 		}
 
 		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)

--- a/src/LibFLExBridge-ChorusPluginTests/Infrastructure/FlexUpdateBranchHelperStrategyTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Infrastructure/FlexUpdateBranchHelperStrategyTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-16 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Globalization;
+using System.Threading;
+using LibFLExBridgeChorusPlugin.Infrastructure;
+using LibTriboroughBridgeChorusPlugin.Infrastructure;
+using NUnit.Framework;
+
+namespace LibFLExBridgeChorusPluginTests.Infrastructure
+{
+	[TestFixture]
+	class FlexUpdateBranchHelperStrategyTests
+	{
+        [Test]
+		[SetCulture("sv-SE")]
+		public void GetModelVersionFromBranchName_HandlesScandinavianCulture()
+		{
+			const string branchName = "75003.74001";
+			var flexUpdateBranchHelper = new FlexUpdateBranchHelperStrategy();
+			double modelVersion = 0;
+            Assert.DoesNotThrow(()=> modelVersion = ((IUpdateBranchHelperStrategy)flexUpdateBranchHelper).GetModelVersionFromBranchName(branchName));
+            Assert.That(modelVersion, Is.EqualTo(75003.74001));
+		}
+	}
+}

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -206,6 +206,7 @@
     <Compile Include="FieldWorksTestServices.cs" />
     <Compile Include="Infrastructure\DataSortingServiceTests.cs" />
     <Compile Include="Infrastructure\FLExProjectSplitterTests.cs" />
+    <Compile Include="Infrastructure\FlexUpdateBranchHelperStrategyTests.cs" />
     <Compile Include="Infrastructure\MetadataCacheTests.cs" />
     <Compile Include="Infrastructure\FLExProjectUnifierTests.cs" />
     <Compile Include="Infrastructure\LibFLExBridgeUtilitiesTests.cs" />


### PR DESCRIPTION
* Parse the branch name using invariant culture to
  avoid crashes when users have their OS displaying
  in Scandinavian languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/282)
<!-- Reviewable:end -->
