### PR TITLE
Fix model version parsing after #263

### DIFF
--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -109,7 +109,7 @@ namespace LfMergeBridge
 			}
 			// See if repo has higher branch than LF called for.
 			var highestHead = LfMergeBridgeUtilities.GetHighestRevision(hgRepository);
-			if (int.Parse(highestHead.Branch) > int.Parse(desiredBranchName))
+			if (double.Parse(highestHead.Branch) > double.Parse(desiredBranchName))
 			{
 				// Clone has a higher data model than LF asked for.
 				Directory.Delete(actualClonePath, true);

--- a/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
@@ -84,7 +84,9 @@ namespace LfMergeBridge
 				return;
 			}
 			var startingRevision = hgRepository.GetRevisionWorkingSetIsBasedOn();
-			var desiredBranchName = options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
+			var desiredModelVersion = updateBranchHelperStrategy.GetModelVersionFromBranchName(desiredBranchName);
 
 			// Do a pull first, to see if FLEx user has upgraded.
 			var uri = options[LfMergeBridgeUtilities.languageDepotRepoUri];
@@ -94,7 +96,7 @@ namespace LfMergeBridge
 			if (pulledChangesFromOthers)
 			{
 				// Check for a higher branch that came in.
-				if (int.Parse(highestHead.Branch) > int.Parse(desiredBranchName))
+				if (updateBranchHelperStrategy.GetModelVersionFromBranchName(highestHead.Branch) > desiredModelVersion)
 				{
 					LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("{0} {1}: pulled a higher model '{2}' than LF asked for '{3}': {4}.", syncBase, LfMergeBridgeUtilities.failure, highestHead.Branch, desiredBranchName, "Sync stopped before local commit"));
 					return;

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexBridgeConstants.cs
@@ -74,6 +74,36 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 		internal const string ModelVersion = "ModelVersion";
 		internal const string ModelVersionFilename = "FLExProject." + ModelVersion;
 
+		// A value that specifies a version of FlexBridge that affects the data written to the
+		// repo, but not the FieldWorks model version. This is part of the branch name, so for
+		// example a version of FlexBridge that is looking for data on branch 7000072 or 7500001.7000072 will not
+		// try to read data on branch 7500002.7000072, even though (if it could PutHumptyTogetherAgain)
+		// its caller would be able to handle 700072 model data. This allows us to change how
+		// FlexBridge handles the data without changing the data model version (which affects other
+		// products and is becoming increasingly expensive to change).
+		// Note that send/receive never tries to handle data on other branches; it only merges with
+		// data on its own branch (though warning if there are new commits on other branches).
+		// Data migration only happens when a new version of FLEx (and FlexBridge) is installed
+		// on a computer that has the data needing migration, and upgrades and does a send/receive;
+		// or when making a new clone of the project using a newer version of FLEx.
+		// Because of this clone-and-upgrade possibility, FlexBridge must be able to
+		// PutHumptyTogetherAgain for both old data models and old Humpty strategies.
+		// Branch names are formed by putting a dot between the FlexBridgeDataVersion and the
+		// Flex Model Version. To avoid crashing versions of FLEx that work with data models
+		// before 700072, the result must parse as a float. To prevent older versions of FlexBridge
+		// from trying to clone data that is too new for them, the float must be larger than
+		// the largest model version before we introduced this new system, 7000072.
+		// This is achieved by putting the FlexBridgeDataVersion before the model version
+		// and making it start with 750000.
+		// Note: we would have preferred to put the FlexBridgeDataVersion second, giving
+		// numbers like 7000072.02. However, we ran out of significance in Float;
+		// float.Parse("7000072.2") is equal to float.Parse("7000072") which means old
+		// versions of FlexBridge would not detect that 7000072.2 is too new for them
+		// to clone. To allow new versions of FLEx to notice that 7500002.7000073 is larger
+		// than 7500002.7000072, we changed float.Parse() to double.Parse(); but we can't
+		// change the old versions.
+		internal const string FlexBridgeDataVersion = "7500002";
+
 		// Custom Properties
 		internal const string AdditionalFieldsTag = "AdditionalFields";
 		internal const string CustomProperties = "CustomProperties";

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
@@ -14,12 +14,12 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 
 		#region IUpdateBranchHelperStrategy impl
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
+		double IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
 		{
-			return uint.Parse(branchName);
+			return double.Parse(branchName);
 		}
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
+		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
 		{
 			var modelVersion = AsIUpdateBranchHelperStrategy.GetFullModelVersion(cloneLocation);
 			return string.IsNullOrEmpty(modelVersion)

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
@@ -5,8 +5,8 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 {
 	internal interface IUpdateBranchHelperStrategy
 	{
-		float GetModelVersionFromBranchName(string branchName);
-		float GetModelVersionFromClone(string cloneLocation);
+		double GetModelVersionFromBranchName(string branchName);
+		double GetModelVersionFromClone(string cloneLocation);
 		string GetFullModelVersion(string cloneLocation);
 	}
 }

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/UpdateBranchHelper.cs
@@ -39,7 +39,7 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 				var gonerKeys = new HashSet<string>();
 				foreach (var headKvp in allHeads)
 				{
-					float currentVersion;
+					double currentVersion;
 					if (headKvp.Key == LibTriboroughBridgeSharedConstants.Default)
 					{
 						repo.Update(headKvp.Value.Number.LocalRevisionNumber);
@@ -96,7 +96,7 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 				}
 
 				// Now. get to the real work.
-				var sortedRevisions = new SortedList<float, Revision>();
+				var sortedRevisions = new SortedList<double, Revision>();
 				foreach (var kvp in allHeads)
 				{
 					sortedRevisions.Add(updateBranchHelperStrategy.GetModelVersionFromBranchName(kvp.Key), kvp.Value);

--- a/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
+++ b/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
@@ -32,12 +32,12 @@ namespace SIL.LiftBridge.Infrastructure
 
 		#region IUpdateBranchHelperStrategy impl
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
+		double IUpdateBranchHelperStrategy.GetModelVersionFromBranchName(string branchName)
 		{
-			return float.Parse(branchName.Replace("LIFT", null));
+			return double.Parse(branchName.Replace("LIFT", null));
 		}
 
-		float IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
+		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
 		{
 			return GetLiftVersionNumber(cloneLocation);
 		}


### PR DESCRIPTION
Now that model versions are doubles, we need to change some of the int.Parse calls in LfMergeBridge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/283)
<!-- Reviewable:end -->
