### PR TITLE
Fix model version parsing after #263

### DIFF
--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -180,7 +180,8 @@ namespace LfMergeBridge
 
 			var user = options.ContainsKey(LfMergeBridgeUtilities.user) ? options[LfMergeBridgeUtilities.user] : null;
 
-			FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, options[LfMergeBridgeUtilities.fdoDataModelVersion], user, DeleteRepoIfNoSuchBranch(options));
+			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, desiredBranchName, user, DeleteRepoIfNoSuchBranch(options));
 		}
 
 		/// <summary>

--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -109,7 +109,9 @@ namespace LfMergeBridge
 			}
 			// See if repo has higher branch than LF called for.
 			var highestHead = LfMergeBridgeUtilities.GetHighestRevision(hgRepository);
-			if (int.Parse(highestHead.Branch) > int.Parse(desiredBranchName))
+			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
+			var desiredModelVersion = updateBranchHelperStrategy.GetModelVersionFromBranchName(desiredBranchName);
+			if (updateBranchHelperStrategy.GetModelVersionFromBranchName(highestHead.Branch) > desiredModelVersion)
 			{
 				// Clone has a higher data model than LF asked for.
 				Directory.Delete(actualClonePath, true);

--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -86,6 +86,14 @@ namespace LfMergeBridge
 					alreadyOnIt = true;
 					break;
 				case HgRepository.UpdateResults.NoSuchBranch:
+					// First check if this is an old-style repo
+					if (desiredBranchName.Contains("."))
+					{
+						var idx = desiredBranchName.IndexOf(".");
+						var oldStyleBranchName = desiredBranchName.Substring(idx + 1);
+						FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, oldStyleBranchName, user, deleteRepoIfNoSuchBranch);
+						return;
+					}
 					// Bail out, since LF doesn't support data migration, which would require creation of a new branch.
 					if (deleteRepoIfNoSuchBranch)
 					{

--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -91,8 +91,12 @@ namespace LfMergeBridge
 					{
 						var idx = desiredBranchName.IndexOf(".");
 						var oldStyleBranchName = desiredBranchName.Substring(idx + 1);
-						FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, oldStyleBranchName, user, deleteRepoIfNoSuchBranch);
-						return;
+						// FLEx versions that use model 7000072 and above know about ###.### branch names, but 7000071 and earlier don't
+						if (System.String.CompareOrdinal(oldStyleBranchName, "7000072") < 0)
+						{
+							FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, oldStyleBranchName, user, deleteRepoIfNoSuchBranch);
+							return;
+						}
 					}
 					// Bail out, since LF doesn't support data migration, which would require creation of a new branch.
 					if (deleteRepoIfNoSuchBranch)

--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -192,7 +192,8 @@ namespace LfMergeBridge
 
 			var user = options.ContainsKey(LfMergeBridgeUtilities.user) ? options[LfMergeBridgeUtilities.user] : null;
 
-			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
+			var desiredBranchName = updateBranchHelperStrategy.GetBranchNameFromModelVersion(options[LfMergeBridgeUtilities.fdoDataModelVersion]);
 			FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, desiredBranchName, user, DeleteRepoIfNoSuchBranch(options));
 		}
 

--- a/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
@@ -84,7 +84,7 @@ namespace LfMergeBridge
 				return;
 			}
 			var startingRevision = hgRepository.GetRevisionWorkingSetIsBasedOn();
-			var desiredBranchName = options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + options[LfMergeBridgeUtilities.fdoDataModelVersion];
 			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
 			var desiredModelVersion = updateBranchHelperStrategy.GetModelVersionFromBranchName(desiredBranchName);
 
@@ -111,10 +111,25 @@ namespace LfMergeBridge
 			}
 			if (branch != desiredBranchName && highestHead.Branch != desiredBranchName)
 			{
-				// Not being the same could create a new branch, and LF doesn't allow that.
-				// It may be that LF ought to have first asked for a branch change.
-				LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("{0} {1}: Cannot commit to current branch '{2}', because LF wants branch '{3}', and that could possibly create a new branch.", syncBase, LfMergeBridgeUtilities.failure, branch, desiredBranchName));
-				return;
+				if (desiredBranchName.Contains("."))
+				{
+					var idx = desiredBranchName.IndexOf('.');
+					var modelNumber = desiredBranchName.Substring(idx+1);
+					if (branch != modelNumber && highestHead.Branch != modelNumber)
+					{
+						// Not being the same could create a new branch, and LF doesn't allow that.
+						// It may be that LF ought to have first asked for a branch change.
+						LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("{0} {1}: Cannot commit to current branch '{2}', because LF wants branch '{3}', and that could possibly create a new branch.", syncBase, LfMergeBridgeUtilities.failure, branch, desiredBranchName));
+						return;
+					}
+				}
+				else
+				{
+					// Not being the same could create a new branch, and LF doesn't allow that.
+					// It may be that LF ought to have first asked for a branch change.
+					LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("{0} {1}: Cannot commit to current branch '{2}', because LF wants branch '{3}', and that could possibly create a new branch.", syncBase, LfMergeBridgeUtilities.failure, branch, desiredBranchName));
+					return;
+				}
 			}
 
 			// Set up adjunct.

--- a/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
@@ -85,6 +85,8 @@ namespace LfMergeBridge
 			}
 			var startingRevision = hgRepository.GetRevisionWorkingSetIsBasedOn();
 			var desiredBranchName = options[LfMergeBridgeUtilities.fdoDataModelVersion];
+			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
+			var desiredModelVersion = updateBranchHelperStrategy.GetModelVersionFromBranchName(desiredBranchName);
 
 			// Do a pull first, to see if FLEx user has upgraded.
 			var uri = options[LfMergeBridgeUtilities.languageDepotRepoUri];
@@ -94,7 +96,7 @@ namespace LfMergeBridge
 			if (pulledChangesFromOthers)
 			{
 				// Check for a higher branch that came in.
-				if (int.Parse(highestHead.Branch) > int.Parse(desiredBranchName))
+				if (updateBranchHelperStrategy.GetModelVersionFromBranchName(highestHead.Branch) > desiredModelVersion)
 				{
 					LfMergeBridgeUtilities.AppendLineToSomethingForClient(ref somethingForClient, string.Format("{0} {1}: pulled a higher model '{2}' than LF asked for '{3}': {4}.", syncBase, LfMergeBridgeUtilities.failure, highestHead.Branch, desiredBranchName, "Sync stopped before local commit"));
 					return;

--- a/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeSendReceiveActionHandler.cs
@@ -84,8 +84,8 @@ namespace LfMergeBridge
 				return;
 			}
 			var startingRevision = hgRepository.GetRevisionWorkingSetIsBasedOn();
-			var desiredBranchName = FlexBridgeConstants.FlexBridgeDataVersion + "." + options[LfMergeBridgeUtilities.fdoDataModelVersion];
 			IUpdateBranchHelperStrategy updateBranchHelperStrategy = new FlexUpdateBranchHelperStrategy();
+			var desiredBranchName = updateBranchHelperStrategy.GetBranchNameFromModelVersion(options[LfMergeBridgeUtilities.fdoDataModelVersion]);
 			var desiredModelVersion = updateBranchHelperStrategy.GetModelVersionFromBranchName(desiredBranchName);
 
 			// Do a pull first, to see if FLEx user has upgraded.

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
@@ -23,6 +23,11 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 			return double.Parse(branchName);
 		}
 
+		string IUpdateBranchHelperStrategy.GetBranchNameFromModelVersion(string modelVersion)
+		{
+			return FlexBridgeConstants.FlexBridgeDataVersion + "." + modelVersion;
+		}
+
 		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)
 		{
 			var modelVersion = AsIUpdateBranchHelperStrategy.GetFullModelVersion(cloneLocation);

--- a/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Infrastructure/IUpdateBranchHelperStrategy.cs
@@ -6,6 +6,7 @@ namespace LibTriboroughBridgeChorusPlugin.Infrastructure
 	internal interface IUpdateBranchHelperStrategy
 	{
 		double GetModelVersionFromBranchName(string branchName);
+		string GetBranchNameFromModelVersion(string modelVersion);
 		double GetModelVersionFromClone(string cloneLocation);
 		string GetFullModelVersion(string cloneLocation);
 	}

--- a/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
+++ b/src/LiftBridge-ChorusPlugin/Infrastructure/UpdateBranchHelperLift.cs
@@ -31,6 +31,11 @@ namespace SIL.LiftBridge.Infrastructure
 			return double.Parse(branchName.Replace("LIFT", null).Split('_')[0], NumberFormatInfo.InvariantInfo);
 		}
 
+		string IUpdateBranchHelperStrategy.GetBranchNameFromModelVersion(string modelVersion)
+		{
+			return "LIFT" + modelVersion + "_ldml3";
+		}
+
 		public double GetModelVersionFromClone(string cloneLocation)
 		{
 			return GetLiftVersionNumber(cloneLocation);


### PR DESCRIPTION
Now that model versions are doubles, we need to change some of the int.Parse calls in LfMergeBridge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/285)
<!-- Reviewable:end -->
