### PR TITLE
Better handle pre-change LfMerge repos

### DIFF
--- a/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
+++ b/src/LfMergeBridge/LanguageForgeMakeCloneActionHandler.cs
@@ -91,12 +91,8 @@ namespace LfMergeBridge
 					{
 						var idx = desiredBranchName.IndexOf(".");
 						var oldStyleBranchName = desiredBranchName.Substring(idx + 1);
-						// FLEx versions that use model 7000072 and above know about ###.### branch names, but 7000071 and earlier don't
-						if (System.String.CompareOrdinal(oldStyleBranchName, "7000072") < 0)
-						{
-							FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, oldStyleBranchName, user, deleteRepoIfNoSuchBranch);
-							return;
-						}
+						FinishClone(progress, ref somethingForClient, cloneBase, actualClonePath, oldStyleBranchName, user, deleteRepoIfNoSuchBranch);
+						return;
 					}
 					// Bail out, since LF doesn't support data migration, which would require creation of a new branch.
 					if (deleteRepoIfNoSuchBranch)

--- a/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Infrastructure/FlexUpdateBranchHelperStrategy.cs
@@ -26,7 +26,9 @@ namespace LibFLExBridgeChorusPlugin.Infrastructure
 
 		string IUpdateBranchHelperStrategy.GetBranchNameFromModelVersion(string modelVersion)
 		{
-			return FlexBridgeConstants.FlexBridgeDataVersion + "." + modelVersion;
+			return (System.String.CompareOrdinal(modelVersion, "7000072") < 0)
+				? modelVersion
+				: FlexBridgeConstants.FlexBridgeDataVersion + "." + modelVersion;
 		}
 
 		double IUpdateBranchHelperStrategy.GetModelVersionFromClone(string cloneLocation)


### PR DESCRIPTION
Repos cloned with LfMerge versions from before the FLExBridge change may have branch name 7000072 in them, so we can't just assume that that branch name won't ever be present. So the conditional in FinishClone was wrong; removing it makes LfMerge unit tests pass again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/291)
<!-- Reviewable:end -->
