### PR TITLE
Clear removed project settings from the cache

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Contexts/BaseDomainServices.cs
@@ -176,42 +176,45 @@ namespace LibFLExBridgeChorusPlugin.Contexts
 																 select osEl.Attribute(FlexBridgeConstants.GuidStr).Value.ToLowerInvariant()).ToList();
 		}
 
-		private static void CopySupportingSettingsFilesIntoRepo(IProgress progress, bool writeVerbose, string pathRoot)
+		internal static void CopySupportingSettingsFilesIntoRepo(IProgress progress, bool writeVerbose, string pathRoot)
 		{
 			progress.WriteMessage("Copying settings files...");
 			// copy the dictionary configuration files into the .hg included repo
 			var dictionaryConfigFolder = Path.Combine(pathRoot, "ConfigurationSettings");
-			if (Directory.Exists(dictionaryConfigFolder))
-			{
-				if (writeVerbose)
-				{
-					progress.WriteMessage("Copying dictionary configuration settings.");
-				}
-				DirectoryHelper.Copy(dictionaryConfigFolder, Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings"), true);
-			}
+			CopyFilesIntoCachedFolderWithFileRemoval(progress, writeVerbose, dictionaryConfigFolder,
+				Path.Combine(pathRoot, "CachedSettings", "ConfigurationSettings"), "Copying dictionary configuration settings.");
 			// copy the lexicon settings files into the.hg included repo
 			var sharedSettingsFolder = Path.Combine(pathRoot, "SharedSettings");
-			if (Directory.Exists(sharedSettingsFolder))
-			{
-				if (writeVerbose)
-				{
-					progress.WriteMessage("Copying shared lexicon settings.");
-				}
-				DirectoryHelper.Copy(sharedSettingsFolder, Path.Combine(pathRoot, "CachedSettings", "SharedSettings"), true);
-			}
+			CopyFilesIntoCachedFolderWithFileRemoval(progress, writeVerbose, sharedSettingsFolder,
+				Path.Combine(pathRoot, "CachedSettings", "SharedSettings"), "Copying shared lexicon settings.");
 			// copy the writing system files into the .hg included repo
 			var wsFolder = Path.Combine(pathRoot, "WritingSystemStore");
-			if (Directory.Exists(wsFolder))
+			CopyFilesIntoCachedFolderWithFileRemoval(progress, writeVerbose, wsFolder,
+				Path.Combine(pathRoot, "CachedSettings", "WritingSystemStore"), "Copying writing systems.");
+		}
+
+		/// <summary>
+		/// Copy the files into the repo location, remove files from the repo that were removed from the local folder.
+		/// </summary>
+		private static void CopyFilesIntoCachedFolderWithFileRemoval(IProgress progress,
+			bool writeVerbose, string sourcePath, string destinationPath, string progressMessage)
+		{
+			if (Directory.Exists(sourcePath))
 			{
 				if (writeVerbose)
 				{
-					progress.WriteMessage("Copying writing systems.");
+					progress.WriteMessage(progressMessage);
 				}
-				DirectoryHelper.Copy(wsFolder, Path.Combine(pathRoot, "CachedSettings", "WritingSystemStore"), true);
+
+				if (Directory.Exists(destinationPath))
+				{
+					RobustIO.DeleteDirectoryAndContents(destinationPath);
+				}
+				DirectoryHelper.Copy(sourcePath, destinationPath, true);
 			}
 		}
 
-		private static void CopySupportingSettingsFilesIntoProjectFolder(IProgress progress, bool writeVerbose, string pathRoot)
+	  private static void CopySupportingSettingsFilesIntoProjectFolder(IProgress progress, bool writeVerbose, string pathRoot)
 		{
 			progress.WriteMessage("Copying settings files...");
 			var cachedSettingsPath = Path.Combine(pathRoot, "CachedSettings");

--- a/src/LibFLExBridge-ChorusPluginTests/Infrastructure/FLExProjectSplitterTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Infrastructure/FLExProjectSplitterTests.cs
@@ -1,13 +1,16 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
+using System.IO;
 using Chorus.Utilities;
+using LibFLExBridgeChorusPlugin.Contexts;
 using LibFLExBridgeChorusPlugin.DomainServices;
 using LibTriboroughBridgeChorusPlugin;
 using NUnit.Framework;
 using SIL.IO;
 using SIL.Progress;
+using SIL.TestUtilities;
 
 namespace LibFLExBridgeChorusPluginTests.Infrastructure
 {
@@ -53,6 +56,43 @@ namespace LibFLExBridgeChorusPluginTests.Infrastructure
 				};
 				var pathname = tempFile.Path;
 				Assert.Throws<UserCancelledException>(() => FLExProjectSplitter.PushHumptyOffTheWall(progress, false, pathname));
+			}
+		}
+
+		[Test]
+		public void CopySupportingSettingsFilesIntoRepo_WritingSystemsCopiedToCache()
+		{
+			// Setup a folder with a writing system to copy and an empty cache folder.
+			using (var tempProjFolder = new TemporaryFolder("WritingSystemsCopiedToCache"))
+			{
+				var wsFolder = Path.Combine(tempProjFolder.Path, "WritingSystemStore");
+				var wsCacheFolder = Path.Combine(tempProjFolder.Path, "CachedSettings", "WritingSystemStore");
+				Directory.CreateDirectory(wsFolder);
+				File.WriteAllText(Path.Combine(wsFolder, "en.ldml"), "<ldml/>");
+				Assert.IsFalse(Directory.Exists(wsCacheFolder));
+				// SUT
+				BaseDomainServices.CopySupportingSettingsFilesIntoRepo(new NullProgress(), false, tempProjFolder.Path);
+				// Verify that the writing system was copied into the cache.
+				Assert.IsTrue(File.Exists(Path.Combine(wsCacheFolder, "en.ldml")));
+			}
+		}
+
+		[Test]
+		public void CopySupportingSettingsFilesIntoRepo_DeletedWritingSystemsRemovedFromCache()
+		{
+			// Setup an empty project writing system store and a cache containing one writing system.
+			using (var tempProjFolder = new TemporaryFolder("DeletedWritingSystemsRemovedFromCache"))
+			{
+				var wsFolder = Path.Combine(tempProjFolder.Path, "WritingSystemStore");
+				var wsCacheFolder = Path.Combine(tempProjFolder.Path, "CachedSettings", "WritingSystemStore");
+				Directory.CreateDirectory(wsFolder);
+				Directory.CreateDirectory(wsCacheFolder);
+				File.WriteAllText(Path.Combine(wsCacheFolder, "en.ldml"), "<ldml/>");
+				Assert.IsFalse(File.Exists(Path.Combine(wsFolder, "en.ldml")));
+				// SUT
+				BaseDomainServices.CopySupportingSettingsFilesIntoRepo(new NullProgress(), false, tempProjFolder.Path);
+				// Verify that the writing system was deleted from the cache
+				Assert.IsFalse(File.Exists(Path.Combine(wsCacheFolder, "en.ldml")));
 			}
 		}
 	}


### PR DESCRIPTION
* Fix LT-20464 - Remove project settings files
  from the cache if they are no longer in the
  source folders

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/295)
<!-- Reviewable:end -->
