### PR TITLE
build: Don't generate assembly info Version, FileVersion, Information…

### DIFF
--- a/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
+++ b/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -27,6 +27,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
+++ b/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RepositoryUtility/RepositoryUtility.csproj
+++ b/src/RepositoryUtility/RepositoryUtility.csproj
@@ -25,6 +25,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     <IsPackable>false</IsPackable>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
@@ -26,6 +26,9 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
     </AppendToReleaseNotesProperty>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…alVersion

- Because it collides with what is specified in project
/Properties/GitVersionTaskAssemblyInfo.g.cs files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/298)
<!-- Reviewable:end -->
