### PR TITLE
Upgrade to GeckoFx 60 and drop 32-bit support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ XDG_CONFIG_HOME ?= /tmp/.config
 UploadFolder="Alpha"
 # Work around proxy bug in older mono to allow dependency downloads
 no_proxy := $(no_proxy),*.local
-GECKOFX45_VERSION := 45.0.36
+GECKOFX60_VERSION := 60.0.51
 
 all: release
 
@@ -29,8 +29,7 @@ release_build:
 	  /p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) /p:Configuration=ReleaseMono \
 	  /p:RestorePackages=false /p:AutoGenerateBindingRedirects=false /v:detailed /p:UpdateAssemblyInfo=false \
 	  /p:WriteVersionInfoToBuildLog=false
-	cp -a packages/Geckofx45.64.Linux.$(GECKOFX45_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx45.64.Linux.$(GECKOFX45_VERSION)/lib/net40
-	cp -a packages/Geckofx45.32.Linux.$(GECKOFX45_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx45.32.Linux.$(GECKOFX45_VERSION)/lib/net40
+	cp -a packages/Geckofx60.64.Linux.$(GECKOFX60_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx60.64.Linux.$(GECKOFX60_VERSION)/lib/net40
 	cp -a flexbridge output/ReleaseMono
 
 debug: vcs_version download_dependencies debug_build
@@ -53,8 +52,7 @@ debug_build:
 	    /p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) /p:Configuration=DebugMono \
 		/p:RestorePackages=false /p:AutoGenerateBindingRedirects=false /p:UpdateAssemblyInfo=false \
 		/p:WriteVersionInfoToBuildLog=false
-	cp -a packages/Geckofx45.64.Linux.$(GECKOFX45_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx45.64.Linux.$(GECKOFX45_VERSION)/lib/net40
-	cp -a packages/Geckofx45.32.Linux.$(GECKOFX45_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx45.32.Linux.$(GECKOFX45_VERSION)/lib/net40
+	cp -a packages/Geckofx60.64.Linux.$(GECKOFX60_VERSION)/build/Geckofx-Core.dll.config packages/Geckofx60.64.Linux.$(GECKOFX60_VERSION)/lib/net40
 	# Put flexbridge next to FLExBridge.exe, as it will be in a user's machine, so FW can easily find it on a developer's machine.
 	cp -a flexbridge output/DebugMono
 

--- a/build/nuget-linux/packages.config
+++ b/build/nuget-linux/packages.config
@@ -1,17 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <!--
-    Download geckofx using nuget, so we can compile using geckofx45
+    Download geckofx using nuget, so we can compile using geckofx60
     from nuget, rather than using it from FieldWorks since we don't
     necessarily know where that will be on a developer's machine. This
     will also be used at run-time on a developer's machine.
 
-    But we don't ship geckofx45, since flexbridge is an architecture-
-    independent package. Instead, geckofx45 from FieldWorks will be
-    used at run-time, when flexbridge is installed from a package.
-
-    Download 32-bit so a developer can run flexbridge on a 32-bit
-    machine using 32-bit geckofx. -->
-  <package id="Geckofx45.64.Linux" version="45.0.36" targetFramework="net45" />
-  <package id="Geckofx45.32.Linux" version="45.0.36" targetFramework="net45" />
+    But we don't ship geckofx60, since geckofx60 from FieldWorks will be
+    used at run-time, when flexbridge is installed from a package. -->
+  <package id="Geckofx60.64.Linux" version="60.0.51"/>
 </packages>

--- a/environ-xulrunner
+++ b/environ-xulrunner
@@ -4,19 +4,14 @@
 # Set GECKOFX to location of Geckofx assemblies. Prepend to MONO_PATH.
 # Set XULRUNNER to location of gecko .so files. Prepend to LD_LIBRARY_PATH.
 
-BITS=64
-if [ "$(arch)" != "x86_64" ]; then
-  BITS=32
-fi
-
 if [ "$RUNMODE" = "INSTALLED" ]; then
     # Use the geckofx shipped with fieldworks. It is not included with
     # flexbridge since flexbridge is architecture independent.
     GECKOFX="/usr/lib/fieldworks"
-    XULRUNNER="${GECKOFX}/Firefox-Linux${BITS}"
+    XULRUNNER="${GECKOFX}/Firefox-Linux64"
 else
-    GECKOFX="$(pwd)/packages/Geckofx45.${BITS}.Linux.45.0.36/lib/net40"
-    XULRUNNER="$(pwd)/packages/Geckofx45.${BITS}.Linux.45.0.36/content/Firefox-Linux${BITS}"
+    GECKOFX="$(pwd)/packages/Geckofx60.64.Linux.60.0.51/lib/net40"
+    XULRUNNER="$(pwd)/packages/Geckofx60.64.Linux.60.0.51/content/Firefox-Linux64"
 fi
 MONO_PATH="$GECKOFX:$MONO_PATH"
 

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -203,11 +203,11 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="Geckofx-Core, Culture=neutral" Condition="'$(OS)'!='Windows_NT'">
       <Private>False</Private>
-      <HintPath>../../packages/Geckofx45.64.Linux.45.0.36/lib/net40/Geckofx-Core.dll</HintPath>
+      <HintPath>../../packages/Geckofx60.64.Linux.60.0.51/lib/net40/Geckofx-Core.dll</HintPath>
     </Reference>
     <Reference Include="Geckofx-Winforms, Culture=neutral" Condition="'$(OS)'!='Windows_NT'">
       <Private>False</Private>
-      <HintPath>../../packages/Geckofx45.64.Linux.45.0.36/lib/net40/Geckofx-Winforms.dll</HintPath>
+      <HintPath>../../packages/Geckofx60.64.Linux.60.0.51/lib/net40/Geckofx-Winforms.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\YamlDotNet.5.2.1\lib\net45\YamlDotNet.dll</HintPath>

--- a/src/RepositoryUtility/RepositoryUtility.csproj
+++ b/src/RepositoryUtility/RepositoryUtility.csproj
@@ -173,13 +173,13 @@
       <SpecificVersion>False</SpecificVersion>
       <Package>Geckofx-Core</Package>
       <Private>False</Private>
-      <HintPath>../../packages/Geckofx45.64.Linux.45.0.36/lib/net40/Geckofx-Core.dll</HintPath>
+      <HintPath>../../packages/Geckofx60.64.Linux.60.0.51/lib/net40/Geckofx-Core.dll</HintPath>
     </Reference>
     <Reference Include="Geckofx-Winforms, Culture=neutral" Condition="'$(OS)'!='Windows_NT'">
       <SpecificVersion>False</SpecificVersion>
       <Package>Geckofx-Winforms</Package>
       <Private>False</Private>
-      <HintPath>../../packages/Geckofx45.64.Linux.45.0.36/lib/net40/Geckofx-Winforms.dll</HintPath>
+      <HintPath>../../packages/Geckofx60.64.Linux.60.0.51/lib/net40/Geckofx-Winforms.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
To match GeckoFx version used by FieldWorks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/308)
<!-- Reviewable:end -->
