### PR TITLE
build: Allow skipping GitVersion

### DIFF
--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -53,13 +53,13 @@
 		<CallTarget Targets="RestoreBuildTasks"/>
 		<CallTarget Targets="BuildInternal" Condition="!$(RestartBuild)" />
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="BuildInternal"
-			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog)"
+			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog);DisableGitVersionTask=$(DisableGitVersionTask)"
 			Condition="$(RestartBuild)" />
 	</Target>
 
 	<Target Name="RestoreBuildTasks" DependsOnTargets="CheckPrerequisites" BeforeTargets="RestorePackages">
 		<Message Text="RestartBuild=$(RestartBuild)"/>
-		<Exec Command='$(NuGetCommand) install GitVersion.MsBuild -excludeVersion -version 5.6.8 -solutionDirectory "$(RootDir)"' />
+		<Exec Command='$(NuGetCommand) install GitVersion.MsBuild -excludeVersion -version 5.6.9 -solutionDirectory "$(RootDir)"' />
 		<Exec Command='$(NuGetCommand) install SIL.BuildTasks -excludeVersion -version 2.5.0 -solutionDirectory "$(RootDir)"' />
 		<Exec Command='$(NuGetCommand) install SIL.ReleaseTasks -excludeVersion -version 2.5.0 -solutionDirectory "$(RootDir)"' />
 		<!-- Install NUnit.Console which has the required extensions as dependencies -->
@@ -120,7 +120,8 @@
 	</Target>
 
 	<Target Name="Compile" DependsOnTargets="CopyExtraFilesToOutput; RestorePackages">
-		<MSBuild Projects="$(RootDir)/$(Solution)" Targets="Build" Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog)"/>
+		<MSBuild Projects="$(RootDir)/$(Solution)" Targets="Build"
+			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog);DisableGitVersionTask=$(DisableGitVersionTask)"/>
 	</Target>
 
 	<Target Name="CopyAbout" DependsOnTargets="SetAssemblyVersion">
@@ -162,7 +163,7 @@
 		<CallTarget Targets="RestoreBuildTasks"/>
 		<CallTarget Targets="PreparePublishingArtifactsInternal" Condition="!$(RestartBuild)" />
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="PreparePublishingArtifactsInternal"
-			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog)"
+			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog);DisableGitVersionTask=$(DisableGitVersionTask)"
 			Condition="$(RestartBuild)" />
 	</Target>
 
@@ -179,7 +180,9 @@
 
 	<Target Name="Test" DependsOnTargets="Build">
 		<CallTarget Targets="TestOnly" Condition="!$(RestartBuild)" />
-		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="TestOnly" Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog)" Condition="$(RestartBuild)" />
+		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="TestOnly"
+			Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog);DisableGitVersionTask=$(DisableGitVersionTask)"
+			Condition="$(RestartBuild)" />
 	</Target>
 
 	<Target Name="TestOnly" >
@@ -203,7 +206,7 @@
 		<MSBuild
 			Projects="$(SolutionPath)"
 			Targets="pack"
-			Properties="Configuration=$(Configuration)" />
+			Properties="Configuration=$(Configuration);DisableGitVersionTask=$(DisableGitVersionTask)" />
 	</Target>
 
 	<!-- *********************** Installer stuff below.  ******************************* -->

--- a/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
+++ b/src/FLEx-ChorusPlugin/FLEx-ChorusPlugin.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
+++ b/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="3.1.0-*" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="3.1.0-*" />

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   <ItemGroup>
     <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
     <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="3.1.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/FwdataNester/FwdataTestApp.csproj
+++ b/src/FwdataNester/FwdataTestApp.csproj
@@ -28,7 +28,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="3.1.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/LfMergeBridgeTestApp/LfMergeBridgeTestApp.csproj
+++ b/src/LfMergeBridgeTestApp/LfMergeBridgeTestApp.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
+++ b/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.TestUtilities" Version="8.0.0-*" />
   </ItemGroup>

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="3.1.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="3.1.0-*" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1-*" IncludeAssets="build" />

--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="3.1.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
+++ b/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="3.1.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
+++ b/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="3.1.0-*" />
   </ItemGroup>

--- a/src/RepositoryUtility/RepositoryUtility.csproj
+++ b/src/RepositoryUtility/RepositoryUtility.csproj
@@ -30,7 +30,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   <ItemGroup>
     <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
     <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/feature/nuget/
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NetSparkle.Net40" Version="1.2.0" />
     <PackageReference Include="SIL.Chorus.App" Version="3.1.0-*" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="3.1.0-*" />

--- a/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
+++ b/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.9" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="3.1.0-*" />
   </ItemGroup>


### PR DESCRIPTION
- gitversion.exe has trouble when used with mono5-sil.
- GitVersion.MsBuild 5.6.9 allows turning off GitVersion by using
/p:DisableGitVersionTask=true .
- Upgrade GitVersion.MsBuild to 5.6.9.
- Forward the DisableGitVersionTask property on.

Addresses #318.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/319)
<!-- Reviewable:end -->
