### PR TITLE
Fix packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ release_build:
 	echo "in Makefile: BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER)"
 	# Don't update the assembly info - there's no git repo during package build
 	cd build \
-		&& msbuild FLExBridge.proj /t:Build /p:GetVersion=false /p:BUILD_NUMBER=$(BUILD_NUMBER) \
+		&& msbuild FLExBridge.proj /t:"SetVersionProperties;Build" /p:GetVersion=false \
+			/p:BUILD_NUMBER=$(BUILD_NUMBER) \
 			/p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) \
 			/p:Configuration=Release /p:RestorePackages=false /p:UpdateAssemblyInfo=false \
 			/p:WriteVersionInfoToBuildLog=false /p:DisableGitVersionTask=true \
@@ -42,7 +43,8 @@ debug_build:
 	export FBCommonAppData
 	# Don't update the assembly info - there's no git repo during package build
 	cd build \
-		&& msbuild FLExBridge.proj /t:Build /p:GetVersion=false /p:BUILD_NUMBER=$(BUILD_NUMBER) \
+		&& msbuild FLExBridge.proj /t:"SetVersionProperties;Build" /p:GetVersion=false \
+			/p:BUILD_NUMBER=$(BUILD_NUMBER) \
 			/p:BUILD_VCS_NUMBER=$(BUILD_VCS_NUMBER) /p:UploadFolder=$(UploadFolder) \
 			/p:Configuration=Debug /p:RestorePackages=false /p:UpdateAssemblyInfo=false \
 			/p:WriteVersionInfoToBuildLog=false /p:DisableGitVersionTask=true \
@@ -55,7 +57,7 @@ debug_build:
 version:
 	[ -e .git ] && cd build \
 		&& export IGNORE_NORMALISATION_GIT_HEAD_MOVE=1 \
-		&& msbuild /t:"RestoreBuildTasks;RestorePackages;UpdateAssemblyInfoForPackage" FLExBridge.proj \
+		&& msbuild /t:"RestoreBuildTasks;RestorePackages" FLExBridge.proj \
 		&& msbuild /t:VersionNumbers FLExBridge.proj || true
 
 # generate the vcs_version file, this hash is used to update the about.htm information

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ init:
       set GITVERSION_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER%
 
       if defined APPVEYOR_PULL_REQUEST_NUMBER set GitVersion_NoNormalizeEnabled=true
+
+      if defined APPVEYOR_PULL_REQUEST_NUMBER set IGNORE_NORMALISATION_GIT_HEAD_MOVE=1
 install:
   - choco install gitversion.portable -pre -y
 nuget:
@@ -16,7 +18,7 @@ nuget:
 before_build:
   - cmd: >-
       if defined APPVEYOR_PULL_REQUEST_NUMBER git checkout -b PR-%APPVEYOR_PULL_REQUEST_NUMBER%
-  - ps: gitversion /l console /output buildserver
+  - ps: gitversion /l console /output buildserver /nonormalize
 build:
   project: build/FLExBridge.proj
   publish_nuget: true

--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -132,10 +132,17 @@
 		<Copy SourceFiles="$(RootDir)/output/Installer/about.htm" DestinationFolder="$(RootDir)/output/$(Configuration)"/>
 	</Target>
 
-	<Target Name="VersionNumbers" DependsOnTargets="RestoreBuildTasks;GetVersion">
-		<WriteLinesToFile File="$(RootDir)/gitversion.properties" Overwrite="true"
-			Lines="BuildVersion=$(GitVersion_SemVer).$(BUILD_NUMBER)"
-			Condition="$(GetVersion)"/>
+	<Target Name="VersionNumbers" DependsOnTargets="RestoreBuildTasks;GetVersion" Condition="$(GetVersion)">
+		<ItemGroup>
+			<GitVersionPropsFile Include="$(RootDir)/gitversion.properties"/>
+		</ItemGroup>
+		<Delete Files="@(GitVersionPropsFile)" />
+
+		<!-- on Jenkins this will create gitversion.properties -->
+		<Exec Command="$(GitVersionFileExe) $(RootDir) -output buildserver -updateprojectfiles" WorkingDirectory="$(RootDir)" />
+		<!-- append build number -->
+		<WriteLinesToFile File="$(RootDir)/gitversion.properties" Overwrite="false"
+			Lines="BuildVersion=$(GitVersion_SemVer).$(BUILD_NUMBER)" />
 	</Target>
 
 	<Target Name="SetAssemblyVersion" DependsOnTargets="VersionNumbers">
@@ -217,8 +224,96 @@
 	<Target Name="Installer" DependsOnTargets="VersionNumbers; BuildRelease; Test" Condition="'$(OS)'=='Windows_NT'"/>
 	<Target Name="Patcher" DependsOnTargets="VersionNumbers; BuildPatch; Test" Condition="'$(OS)'=='Windows_NT'"/>
 
-	<!-- update the AssemblyInfo files for linux packaging -->
-	<Target Name="UpdateAssemblyInfoForPackage">
-		<Exec Command="for f in `find $(RootDir) -name packages.config -print0 | xargs -0 grep --files-with-matches GitVersion`; do dir=`dirname $f`; msbuild /t:UpdateAssemblyInfo /p:IntermediateOutputPath=Properties $dir/`basename $dir`.csproj; done" />
+	<!-- When package building we don't a .git subdirectory, so can't run GitVersion directly.
+		Instead we did run it when creating the source package, so we now have a gitversion.json
+		file that contains all relevant values. Usually this file gets read by the GetVersion
+		target, but that only works if we also run gitversion itself. So instead we duplicate
+		that target here. -->
+	<Target Name="SetVersionProperties">
+	   <GetVersion SolutionDirectory="$(GitVersionPath)" VersionFile="$(GitVersionOutputFile)">
+			<Output TaskParameter="Major" PropertyName="GitVersion_Major" />
+			<Output TaskParameter="Minor" PropertyName="GitVersion_Minor" />
+			<Output TaskParameter="Patch" PropertyName="GitVersion_Patch" />
+			<Output TaskParameter="PreReleaseTag" PropertyName="GitVersion_PreReleaseTag" />
+			<Output TaskParameter="PreReleaseTagWithDash" PropertyName="GitVersion_PreReleaseTagWithDash" />
+			<Output TaskParameter="PreReleaseLabel" PropertyName="GitVersion_PreReleaseLabel" />
+			<Output TaskParameter="PreReleaseLabelWithDash" PropertyName="GitVersion_PreReleaseLabelWithDash" />
+			<Output TaskParameter="PreReleaseNumber" PropertyName="GitVersion_PreReleaseNumber" />
+			<Output TaskParameter="WeightedPreReleaseNumber" PropertyName="GitVersion_WeightedPreReleaseNumber" />
+			<Output TaskParameter="MajorMinorPatch" PropertyName="GitVersion_MajorMinorPatch" />
+			<Output TaskParameter="SemVer" PropertyName="GitVersion_SemVer" />
+			<Output TaskParameter="LegacySemVer" PropertyName="GitVersion_LegacySemVer" />
+			<Output TaskParameter="LegacySemVerPadded" PropertyName="GitVersion_LegacySemVerPadded" />
+			<Output TaskParameter="AssemblySemVer" PropertyName="GitVersion_AssemblySemVer" />
+			<Output TaskParameter="AssemblySemFileVer" PropertyName="GitVersion_AssemblySemFileVer" />
+			<Output TaskParameter="FullSemVer" PropertyName="GitVersion_FullSemVer" />
+			<Output TaskParameter="InformationalVersion" PropertyName="GitVersion_InformationalVersion" />
+			<Output TaskParameter="BranchName" PropertyName="GitVersion_BranchName" />
+			<Output TaskParameter="EscapedBranchName" PropertyName="GitVersion_EscapedBranchName" />
+			<Output TaskParameter="Sha" PropertyName="GitVersion_Sha" />
+			<Output TaskParameter="ShortSha" PropertyName="GitVersion_ShortSha" />
+			<Output TaskParameter="NuGetVersionV2" PropertyName="GitVersion_NuGetVersionV2" />
+			<Output TaskParameter="NuGetVersion" PropertyName="GitVersion_NuGetVersion" />
+			<Output TaskParameter="NuGetPreReleaseTagV2" PropertyName="GitVersion_NuGetPreReleaseTagV2" />
+			<Output TaskParameter="NuGetPreReleaseTag" PropertyName="GitVersion_NuGetPreReleaseTag" />
+			<Output TaskParameter="CommitDate" PropertyName="GitVersion_CommitDate" />
+			<Output TaskParameter="VersionSourceSha" PropertyName="GitVersion_VersionSourceSha" />
+			<Output TaskParameter="CommitsSinceVersionSource" PropertyName="GitVersion_CommitsSinceVersionSource" />
+			<Output TaskParameter="CommitsSinceVersionSourcePadded" PropertyName="GitVersion_CommitsSinceVersionSourcePadded" />
+			<Output TaskParameter="UncommittedChanges" PropertyName="GitVersion_UncommittedChanges" />
+		</GetVersion>
+
+		<PropertyGroup>
+			<Version>$(GitVersion_FullSemVer)</Version>
+			<VersionPrefix>$(GitVersion_MajorMinorPatch)</VersionPrefix>
+			<VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetPreReleaseTag)</VersionSuffix>
+			<VersionSuffix Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_PreReleaseTag)</VersionSuffix>
+			<PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'false' ">$(GitVersion_NuGetVersion)</PackageVersion>
+			<PackageVersion Condition=" '$(UseFullSemVerForNuGet)' == 'true' ">$(GitVersion_FullSemVer)</PackageVersion>
+			<InformationalVersion Condition=" '$(InformationalVersion)' == '' ">$(GitVersion_InformationalVersion)</InformationalVersion>
+			<AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">$(GitVersion_AssemblySemVer)</AssemblyVersion>
+			<FileVersion Condition=" '$(FileVersion)' == '' ">$(GitVersion_AssemblySemFileVer)</FileVersion>
+			<RepositoryBranch Condition=" '$(RepositoryBranch)' == '' ">$(GitVersion_BranchName)</RepositoryBranch>
+			<RepositoryCommit Condition=" '$(RepositoryCommit)' == '' ">$(GitVersion_Sha)</RepositoryCommit>
+		</PropertyGroup>
+
+		<PropertyGroup Condition=" '$(WixTargetsImported)' == 'true' And '$(GenerateGitVersionWixDefines)' == 'true' ">
+			<DefineConstants Condition=" '$(GitVersion_Major)' != '' ">GitVersion_Major=$(GitVersion_Major);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_Minor)' != '' ">GitVersion_Minor=$(GitVersion_Minor);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_Patch)' != '' ">GitVersion_Patch=$(GitVersion_Patch);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_PreReleaseTag)' != '' ">GitVersion_PreReleaseTag=$(GitVersion_PreReleaseTag);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_PreReleaseTagWithDash)' != '' ">GitVersion_PreReleaseTagWithDash=$(GitVersion_PreReleaseTagWithDash);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_PreReleaseLabel)' != '' ">GitVersion_PreReleaseLabel=$(GitVersion_PreReleaseLabel);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_PreReleaseLabelWithDash)' != '' ">GitVersion_PreReleaseLabelWithDash=$(GitVersion_PreReleaseLabeWithDashl);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_PreReleaseNumber)' != '' ">GitVersion_PreReleaseNumber=$(GitVersion_PreReleaseNumber);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_WeightedPreReleaseNumber)' != '' ">GitVersion_WeightedPreReleaseNumber=$(GitVersion_WeightedPreReleaseNumber);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_BuildMetaData)' != '' ">GitVersion_BuildMetaData=$(GitVersion_BuildMetaData);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_BuildMetaDataPadded)' != '' ">GitVersion_BuildMetaDataPadded=$(GitVersion_BuildMetaDataPadded);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_FullBuildMetaData)' != '' ">GitVersion_FullBuildMetaData=$(GitVersion_FullBuildMetaData);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_MajorMinorPatch)' != '' ">GitVersion_MajorMinorPatch=$(GitVersion_MajorMinorPatch);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_SemVer)' != '' ">GitVersion_SemVer=$(GitVersion_SemVer);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_LegacySemVer)' != '' ">GitVersion_LegacySemVer=$(GitVersion_LegacySemVer);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_LegacySemVerPadded)' != '' ">GitVersion_LegacySemVerPadded=$(GitVersion_LegacySemVerPadded);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_AssemblySemVer)' != '' ">GitVersion_AssemblySemVer=$(GitVersion_AssemblySemVer);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_AssemblySemFileVer)' != '' ">GitVersion_AssemblySemFileVer=$(GitVersion_AssemblySemFileVer);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_FullSemVer)' != '' ">GitVersion_FullSemVer=$(GitVersion_FullSemVer);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_InformationalVersion)' != '' ">GitVersion_InformationalVersion=$(GitVersion_InformationalVersion);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_BranchName)' != '' ">GitVersion_BranchName=$(GitVersion_BranchName);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_EscapedBranchName)' != '' ">GitVersion_EscapedBranchName=$(GitVersion_EscapedBranchName);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_Sha)' != '' ">GitVersion_Sha=$(GitVersion_Sha);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_ShortSha)' != '' ">GitVersion_ShortSha=$(GitVersion_ShortSha);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_NuGetVersionV2)' != '' ">GitVersion_NuGetVersionV2=$(GitVersion_NuGetVersionV2);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_NuGetVersion)' != '' ">GitVersion_NuGetVersion=$(GitVersion_NuGetVersion);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_NuGetPreReleaseTagV2)' != '' ">GitVersion_NuGetPreReleaseTagV2=$(GitVersion_NuGetPreReleaseTagV2);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_NuGetPreReleaseTag)' != '' ">GitVersion_NuGetPreReleaseTag=$(GitVersion_NuGetPreReleaseTag);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_CommitDate)' != '' ">GitVersion_CommitDate=$(GitVersion_CommitDate);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_VersionSourceSha)' != '' ">GitVersion_VersionSourceSha=$(GitVersion_VersionSourceSha);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_CommitsSinceVersionSource)' != '' ">GitVersion_CommitsSinceVersionSource=$(GitVersion_CommitsSinceVersionSource);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_CommitsSinceVersionSourcePadded)' != '' ">GitVersion_CommitsSinceVersionSourcePadded=$(GitVersion_CommitsSinceVersionSourcePadded);$(DefineConstants)</DefineConstants>
+			<DefineConstants Condition=" '$(GitVersion_UncommittedChanges)' != '' ">GitVersion_UncommittedChanges=$(GitVersion_UncommittedChanges);$(DefineConstants)</DefineConstants>
+		</PropertyGroup>
+
+		<Message Text="In SetVersionProperties: UpdateVersionProperties=$(UpdateVersionProperties), Version=$(Version)" />
 	</Target>
+
 </Project>

--- a/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
+++ b/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="4.0.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="4.0.0" />
   </ItemGroup>

--- a/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
+++ b/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.TestUtilities" Version="8.0.0-*" />
   </ItemGroup>
 

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="4.0.0" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1-*" IncludeAssets="build" />
   </ItemGroup>

--- a/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
+++ b/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
+++ b/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Allow to build package without running gitversion during binary package build. Instead run gitversion before creating the source
package which creates a json file. Then during binary package build we use the json file to populate the necessary properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/324)
<!-- Reviewable:end -->
