### PR TITLE
Bump geckofx from 45 to 60

### DIFF
--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -30,8 +30,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
-    <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
+    <PackageReference Include="Geckofx60.64.Linux" Version="60.0.51.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="4.0.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />

--- a/src/RepositoryUtility/RepositoryUtility.csproj
+++ b/src/RepositoryUtility/RepositoryUtility.csproj
@@ -28,8 +28,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
-    <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
+    <PackageReference Include="Geckofx60.64.Linux" Version="60.0.51.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
- When FW 9.1 launches FB 3.3.0, FW is using geckofx 60.0.51.0 and FB
has geckofx 45.0.37. There is quickly a segfault with little
explanation.
- Update FB to use geckofx 60.
- There is no 32-bit for Geckofx v60.0.51.0, tho there does appear to
be 32-bit versions for following versions. Remove 32-bit package
reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/330)
<!-- Reviewable:end -->
