### PR TITLE
Update path in Linux launcher for dev machines

### DIFF
--- a/flexbridge
+++ b/flexbridge
@@ -31,7 +31,7 @@ cd "${scriptdir}"
 		cp -a "/var/lib/flexbridge/localizations" "${FB_SHARE}"
 	else
 		# For developer build. This is still not working correctly.
-		cp -a "${prefix}/DistFiles/localizations" "${FB_SHARE}"
+		cp -a "${prefix}/../DistFiles/localizations" "${FB_SHARE}"
 	fi
 )
 


### PR DESCRIPTION
Since `net461` is now on the path to the script in the output
directory on dev machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/332)
<!-- Reviewable:end -->
