### PR TITLE
build: Update vscode build tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,11 +3,10 @@
   // for the documentation about the tasks.json format
   "version": "2.0.0",
   "tasks": [
-    // A quick start at build specifying, which much room for improvement.
     {
       "label": "Build",
       "type": "shell",
-      "command": "make debug_build",
+      "command": "msbuild ${workspaceRoot}/build/FLExBridge.proj",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -17,7 +16,7 @@
       ]
     },
     {
-      "label": "Initial build",
+      "label": "make debug",
       "type": "shell",
       "command": "make debug",
       "group": "build",


### PR DESCRIPTION
- There isn't a `make debug_build` now.
- Make the default build option to build with msbuild. Retain the
`make debug` build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/335)
<!-- Reviewable:end -->
