### PR TITLE
Fix Palaso localization

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="RemoveExtraFiles" Condition="'$(OS)'=='Windows_NT'" AfterTargets="Build">
+		<!-- On Linux, FLEx Bridge needs Geckofx. On Windows, the Geckofx DLL's need to be present for the build to succeed, but
+			their presence prevents L10nSharp from extracting strings for localization, since the Linux Geckofx DLL's can't be loaded.
+			Deleting them here fixes both developer builds in Visual Studio and installer builds on the server. -->
+		<ItemGroup>
+			<GeckofxDlls Include="$(MSBuildThisFiledirectory)/output/$(Configuration)/net461/Geckofx-*"/>
+		</ItemGroup>
+		<Delete Files="@(GeckofxDlls)"/>
+	</Target>
+</Project>

--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -112,23 +112,19 @@
 		<LinuxLauncherFiles Include="$(RootDir)/flexbridge"/>
 	</ItemGroup>
 
-	<Target Name="CopyExtraFilesToOutput" DependsOnTargets="CopyExtraFilesToOutputWindows;CopyExtraFilesToOutputLinux"/>
+	<Target Name="CopyExtraFilesToOutput" DependsOnTargets="CopyExtraFilesToOutputLinux">
+		<Error Text="Localization Files Missing" Condition="'@(LocalizeFiles)' == ''" />
+		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461/localizations"/>
+	</Target>
 
 	<Target Name="CopyExtraFilesToOutputLinux" Condition="'$(OS)'!='Windows_NT'">
-		<Error Text="Localization Files Missing" Condition="'@(LocalizeFiles)' == ''" />
 		<Error Text="GeckoBrowserAdapter Missing" Condition="'@(GeckoBrowserFiles)' == ''" />
 		<Copy SourceFiles="@(LinuxLauncherFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
 		<Copy SourceFiles="@(EnchantFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461/localizations"/>
 		<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
 		<Copy SourceFiles="@(ChorusHubFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
 		<Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
 		<Copy SourceFiles="@(GeckoBrowserFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-	</Target>
-
-	<Target Name="CopyExtraFilesToOutputWindows" Condition="'$(OS)'=='Windows_NT'">
-		<Error Text="Localization Files Missing" Condition="'@(LocalizeFiles)' == ''" />
-		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461/localizations"/>
 	</Target>
 
 	<Target Name="Compile" DependsOnTargets="CopyExtraFilesToOutput; RestorePackages; DownloadDependencies">

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 SIL International
+// Copyright (c) 2010-2021 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -97,8 +97,8 @@ namespace TriboroughBridge_ChorusPlugin
 				// This is safer than Application.ProductVersion, which might contain words like 'alpha' or 'beta',
 				// which (on the SECOND run of the program) fail when L10NSharp tries to make a Version object out of them.
 				var versionObj = Assembly.GetExecutingAssembly().GetName().Version;
-				// We don't need to reload strings for every "revision" (that might be every time we build).
-				var version = "" + versionObj.Major + "." + versionObj.Minor + "." + versionObj.Build;
+				// We don't need to reload strings for every "revision" (that might be every time we build). REVIEW (Hasso) 2021.08: then why do we have `build`?
+				var version = $"{versionObj.Major}.{versionObj.Minor}.{versionObj.Build}";
 				var flexBridgeLocMan = LocalizationManager.Create(TranslationMemory.XLiff, desiredUiLangId, FlexBridge, Application.ProductName,
 					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus,
 					FlexLocalizationEmailAddress, FlexBridge, "TriboroughBridge_ChorusPlugin", "FLEx_ChorusPlugin", "SIL.LiftBridge");
@@ -116,7 +116,7 @@ namespace TriboroughBridge_ChorusPlugin
 				versionObj = Assembly.GetAssembly(typeof(ErrorReport)).GetName().Version;
 				version = "" + versionObj.Major + "." + versionObj.Minor + "." + versionObj.Build;
 				var palasoLocMan = LocalizationManager.Create(TranslationMemory.XLiff, desiredUiLangId, "Palaso", "Palaso",
-					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, "Palaso");
+					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, "SIL");
 				results.Add("Palaso", palasoLocMan);
 			}
 			catch


### PR DESCRIPTION
* Look for Palaso classes in the SIL.* namespace
* Consolidate copying of localization files
* Delete Geckofx assets after Windows builds
  (they are required for building, but if they are present
  at runtime, L10nSharp cannot extracts strings to localize)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/337)
<!-- Reviewable:end -->
