### PR TITLE
launch: Optionally listen for debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,8 @@
         // Note that FLExBridge is run in the environment inherited from FieldWorks, such as set by FW environ.
         // Path to enviromnent settings for FieldWorks. This is handled by a mono wrapper script in /opt.
         "MONO_ENVIRON": "${workspaceRoot}/../fw/environ",
+        // Make Chorus print hg debugging info.
+        "CHORUSDEBUGGING": "true",
       },
       "cwd": "${workspaceRoot}"
     },
@@ -44,7 +46,7 @@
       "type": "mono",
       "request": "attach",
       "address": "localhost",
-      "port": 55555
+      "port": 55502
     }
   ]
 }

--- a/flexbridge
+++ b/flexbridge
@@ -11,10 +11,14 @@ set -e -o pipefail
 # incompatible with our version of Mercurial
 export HGRCPATH=
 
-scriptdir="$(dirname "$0")"
-prefix=$(cd "$scriptdir/../.."; /bin/pwd)
+if [[ ${CHORUSDEBUGGING-} == "true" ]]; then
+  # Note: Change to suspend=y to pause until a debugger attaches.
+  FB_MONO_ARGS="${FB_MONO_ARGS-} --debugger-agent=transport=dt_socket,server=y,address=127.0.0.1:55502,suspend=n"
+fi
+script_dir="$(dirname "$0")"
+prefix=$(cd "${script_dir}/../.."; /bin/pwd)
 
-cd "${scriptdir}"
+cd "${script_dir}"
 
 (
 	XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME}/.local/share}
@@ -36,4 +40,4 @@ cd "${scriptdir}"
 )
 
 cd - >/dev/null
-mono --debug "${scriptdir}"/FLExBridge.exe "$@"
+mono --debug ${FB_MONO_ARGS-} "${script_dir}"/FLExBridge.exe "$@"

--- a/lib/common/chorusmerge
+++ b/lib/common/chorusmerge
@@ -1,2 +1,10 @@
-#!/bin/sh
-exec mono `dirname $0`/ChorusMerge.exe "$@"
+#!/bin/bash
+set -ueo pipefail
+script_dir="$(dirname "$0")"
+
+if [[ ${CHORUSDEBUGGING-} == "true" ]]; then
+  # Note: Change to suspend=y to pause until a debugger attaches.
+  CHORUS_MONO_ARGS="${CHORUS_MONO_ARGS-} --debugger-agent=transport=dt_socket,server=y,address=127.0.0.1:55503,suspend=n"
+fi
+
+exec mono --debug ${CHORUS_MONO_ARGS-} "${script_dir}"/ChorusMerge.exe "$@"


### PR DESCRIPTION
- Usage: Set CHORUSDEBUGGING=true before launching.
- FB_MONO_ARGS and CHORUS_MONO_ARGS will allow other custom
commandline arguments to be externally set if helpful.
- Use non-default port 55502 for FlexBridge, and 55503 for
ChorusMerge, to not collide with others.
- Note that CHORUSDEBUGGING is also used by Chorus to print hg
debugging output. Setting in launch.json to set it for Chorus when
launching from launch.json, which should result both in hg debugging
output as well as listening for a debugger when ChorusMerge is later
run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/339)
<!-- Reviewable:end -->
