### PR TITLE
LT-20773: FlexBridge has two Main() entry points.  Use Gtk3 in both.

### DIFF
--- a/src/FLExBridge/Program.cs
+++ b/src/FLExBridge/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2020 SIL International
+// Copyright (c) 2010-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -13,6 +13,7 @@ using SIL.IO;
 using SIL.Progress;
 using SIL.Reporting;
 using SIL.Windows.Forms.HotSpot;
+using SIL.Windows.Forms.Miscellaneous;
 using TriboroughBridge_ChorusPlugin;
 using TriboroughBridge_ChorusPlugin.Infrastructure;
 using TriboroughBridge_ChorusPlugin.Properties;
@@ -58,6 +59,9 @@ namespace FLExBridge
 			}
 
 			SetUpErrorHandling();
+
+			// Use Gtk3
+			GraphicsManager.GtkVersionInUse = GraphicsManager.GTK3;
 
 			var options = CommandLineProcessor.ParseCommandLineArgs(args);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/347)
<!-- Reviewable:end -->
