### PR TITLE
Fix settings migration crash

### DIFF
--- a/src/FLExBridge/Program.cs
+++ b/src/FLExBridge/Program.cs
@@ -52,9 +52,9 @@ namespace FLExBridge
 				// exception handler.
 			}
 
-			Settings.UpgradeSettingsIfNecessary(Settings.Default, Application.CompanyName, Application.ProductName);
-
 			SetUpErrorHandling();
+
+			Settings.UpgradeSettingsIfNecessary(Settings.Default, Application.CompanyName, Application.ProductName);
 
 			// Use Gtk3
 			GraphicsManager.GtkVersionInUse = GraphicsManager.GTK3;

--- a/src/LibTriboroughBridge-ChorusPlugin/Properties/Settings.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Properties/Settings.cs
@@ -51,6 +51,7 @@ namespace LibTriboroughBridgeChorusPlugin.Properties
 			var newSettingsFilePath = Path.Combine(newSettingsDir, settingsFileName);
 			if (FileUtils.FileExists(latestOldSettingsFile) && !FileUtils.FileExists(newSettingsFilePath))
 			{
+				FileUtils.EnsureDirectoryExists(newSettingsDir);
 				FileUtils.Copy(latestOldSettingsFile, newSettingsFilePath);
 			}
 		}

--- a/src/LibTriboroughBridge-ChorusPlugin/Properties/Settings.cs
+++ b/src/LibTriboroughBridge-ChorusPlugin/Properties/Settings.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using SIL.LCModel.Utils;
 using SIL.PlatformUtilities;
+using SIL.Reporting;
 
 namespace LibTriboroughBridgeChorusPlugin.Properties
 {
@@ -25,10 +26,24 @@ namespace LibTriboroughBridgeChorusPlugin.Properties
 				return;
 			}
 
-			MigrateNonCrossPlatformSettings(companyName, appName);
+			TryTo(() => MigrateNonCrossPlatformSettings(companyName, appName));
 
-			settings.Upgrade();
+			TryTo(settings.Upgrade);
+
+			// Whether or not we succeeded, don't try again.
 			settings.CallUpgrade = false;
+		}
+
+		private static void TryTo(Action doThis)
+		{
+			try
+			{
+				doThis();
+			}
+			catch (Exception e)
+			{
+				ErrorReport.ReportNonFatalExceptionWithMessage(e, "Failed to upgrade settings");
+			}
 		}
 
 		internal static void MigrateNonCrossPlatformSettings(string companyName, string appName)

--- a/src/LibTriboroughBridge-ChorusPluginTests/SettingsTests.cs
+++ b/src/LibTriboroughBridge-ChorusPluginTests/SettingsTests.cs
@@ -67,6 +67,8 @@ namespace LibTriboroughBridge_ChorusPluginTests
 			var newSettingsFilePath = Path.Combine(NewAppDirPath, prevVer, SettingsFileName);
 			Assert.That(FileUtils.FileExists(newSettingsFilePath));
 			Assert.That(_fileOs.ReadAllText(newSettingsFilePath), Is.EqualTo(prevConfigXml));
+			Assert.That(FileUtils.DirectoryExists(Path.GetDirectoryName(newSettingsFilePath)),
+				"MockFileOS doesn't always care about directories existing. Real filesystems do.");
 		}
 
 		[Test]

--- a/src/RepositoryUtility/Program.cs
+++ b/src/RepositoryUtility/Program.cs
@@ -49,10 +49,10 @@ namespace RepositoryUtility
 				// exception handler.
 			}
 
+			SetUpErrorHandling();
+
 			LibTriboroughBridgeChorusPlugin.Properties.Settings.UpgradeSettingsIfNecessary(Settings.Default,
 				Application.CompanyName, SettingsProvider.ProductNameForSettings);
-
-			SetUpErrorHandling();
 
 			// Use Gtk3
 			GraphicsManager.GtkVersionInUse = GraphicsManager.GTK3;


### PR DESCRIPTION
Ensure the new settings directory exists before
trying to copy the old settings file into it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/348)
<!-- Reviewable:end -->
