### PR TITLE
Update Mercurial, Remove outdated setup step for cacert path

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,8 +33,6 @@ FLEx Bridge depends on several assemblies from Chorus and Palaso. Those are inst
 
 - On **Linux**, `export FLEXBRIDGEDIR=${HOME}/fwrepo/flexbridge/output/Debug/net461`
 
-TODO: If you plan to Send and Receive to the Internet with High bandwidth, you will need to edit flexbridge\Mercurial\default.d\cacerts.rc to contain the correct path to flexbridge\Mercurial\cacert.pem. Since this must be an absolute path, and this file seems to be overwritten on each build, we should create a build step to take care of this. See https://jira.sil.org/browse/LT-20563
-
 ### Build
 
 You should be able to build solution `FLExBridge.sln` from Visual Studio 2019 Community Edition or

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1" IncludeAssets="build" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.2" IncludeAssets="build" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The step is completed by https://github.com/sillsdev/Mercurial4Chorus/pull/2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/351)
<!-- Reviewable:end -->
