### PR TITLE
Fix installer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 	<OutputPath>../../output/$(Configuration)</OutputPath>
 	<PackageOutputPath>../../output</PackageOutputPath>
 	<SignAssembly>true</SignAssembly>
-	<AssemblyOriginatorKeyFile>../../Flexbridge.snk</AssemblyOriginatorKeyFile>
+	<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/Flexbridge.snk</AssemblyOriginatorKeyFile>
 	<ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
 	<IncludeSymbols>true</IncludeSymbols>
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/build/WixPatchableInstaller.targets
+++ b/build/WixPatchableInstaller.targets
@@ -65,7 +65,7 @@
 
 	<!-- Compile Product and Installer Custom Actions -->
 	<Target Name="ProductCompile" DependsOnTargets="Build">
-		<MSBuild Projects="$(RootDir)/src/WiXInstaller/CustomActions/CustomActions.sln" Properties="Configuration=release;Platform=x86" />
+		<MSBuild Projects="$(RootDir)/src/WiXInstaller/CustomActions/CustomActions.sln" Properties="Configuration=Release;Platform=x86" />
 	</Target>
 
 	<!-- used by target Clean in FLExBridge.proj -->


### PR DESCRIPTION
* Hide our Directory.Build.props from installer projects (in installer repo)
* Use a stable path to Flexbridge.snk, just in case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/352)
<!-- Reviewable:end -->

‼️ Important: This should not be merged until https://build.palaso.org/buildConfiguration/FLExBridgeDevelopWin32InstallerSansPublish?mode=builds build successfully