### PR TITLE
Fix LT-20923: Use invariant culture in date ToString

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Handling/PreferMostRecentTimePreMerger.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/PreferMostRecentTimePreMerger.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2010-2017 SIL International
+// Copyright (c) 2010-2017 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml;
 using Chorus.merge.xml.generic;
@@ -43,7 +44,7 @@ namespace LibFLExBridgeChorusPlugin.Handling
 				// something else besides the timestamp changed. Set timestamp to current time.
 				newestDateTime = DateTimeProvider.Current.UtcNow;
 			}
-			var newestDateTimeString = newestDateTime.ToString("yyyy-M-d H:m:s.fff");
+			var newestDateTimeString = newestDateTime.ToString("yyyy-M-d H:m:s.fff", CultureInfo.InvariantCulture);
 			UpdateDateTimeVal(newestDateTimeString, ourDateTimeNode);
 			UpdateDateTimeVal(newestDateTimeString, theirDateTimeNode);
 		}

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/BaseFieldWorksTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/BaseFieldWorksTypeHandlerTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
+using System.Globalization;
 using System.Xml;
 using Chorus.FileTypeHandlers;
 using LibFLExBridgeChorusPlugin.Infrastructure;
@@ -50,10 +51,7 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 
 		public static DateTime _expectedUtcDateTime;
 
-		public static string ExpectedUtcDateTimeString
-		{
-			get { return ExpectedDateTime.ToString("yyyy-M-d H:m:s.fff"); }
-		}
+		public static string ExpectedUtcDateTimeString => ExpectedDateTime.ToString("yyyy-M-d H:m:s.fff", CultureInfo.InvariantCulture);
 
 		public static DateTime ExpectedDateTime
 		{
@@ -73,6 +71,5 @@ namespace LibFLExBridgeChorusPluginTests.Handling
 					_expectedUtcDateTime.Millisecond);
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
* The PreMerger for time would generate culture specific strings
  causing validation issues in FieldWorks after a merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/360)
<!-- Reviewable:end -->
