### PR TITLE
Use GitVersion_WeightedPreReleaseNumber

### DIFF
--- a/build/WixPatchableInstaller.targets
+++ b/build/WixPatchableInstaller.targets
@@ -32,7 +32,7 @@
 	<Target Name="InstallerVersionNumbers" DependsOnTargets="VersionNumbers">
 		<PropertyGroup>
 			<PreReleaseNumber>$(GitVersion_PreReleaseNumber)</PreReleaseNumber>
-			<PreReleaseNumber Condition="'$(PreReleaseNumber)'==''">$([MSBuild]::Multiply($(BUILD_NUMBER), 10))</PreReleaseNumber>
+			<PreReleaseNumber Condition="'$(PreReleaseNumber)'==''">$(GitVersion_WeightedPreReleaseNumber)</PreReleaseNumber>
 			<MajorVersion>$(GitVersion_Major)</MajorVersion>
 			<MinorVersion>$(MajorVersion).$(GitVersion_Minor)</MinorVersion>
 			<PatchVersion>$(MinorVersion).$(GitVersion_Patch)</PatchVersion>


### PR DESCRIPTION
GitVersion_WeightedPreReleaseNumber is always set, and is higher for release builds than prerelease builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/365)
<!-- Reviewable:end -->
