### PR TITLE
Use chorus 5.0.0-beta* nuget packages instead of 5.0.0-*

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,5 +25,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
 	<ChangelogFile>../../CHANGELOG.md</ChangelogFile>
 	<UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+	<ChorusVersion>5.0.0-beta*</ChorusVersion>
+	<LCModelVersion>10.2.0-beta*</LCModelVersion>
   </PropertyGroup>
 </Project>

--- a/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
+++ b/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>FLEx_ChorusPluginTests</RootNamespace>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-*" />
-    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="$(ChorusVersion)" />
+    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Geckofx60.64.Linux" Version="60.0.51.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
+++ b/src/LfMergeBridgeTests/LfMergeBridgeTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>LfMergeBridgeTests</RootNamespace>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>LibFLExBridgeChorusPluginTests</RootNamespace>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.2" IncludeAssets="build" />
   </ItemGroup>
 

--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
-    <PackageReference Include="SIL.LCModel.Utils" Version="10.2.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
+    <PackageReference Include="SIL.LCModel.Utils" Version="$(LCModelVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LibTriboroughBridge-ChorusPluginTests/LibTriboroughBridge-ChorusPluginTests.csproj
+++ b/src/LibTriboroughBridge-ChorusPluginTests/LibTriboroughBridge-ChorusPluginTests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.LCModel.Utils.Tests" Version="10.2.0-*" />
-    <PackageReference Include="SIL.LCModel.Utils" Version="10.2.0-*" />
+    <PackageReference Include="SIL.LCModel.Utils.Tests" Version="$(LCModelVersion)" />
+    <PackageReference Include="SIL.LCModel.Utils" Version="$(LCModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
+++ b/src/LiftBridge-ChorusPlugin/LiftBridge-ChorusPlugin.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
+++ b/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>LiftBridgeTests</RootNamespace>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LiftFileCheckerApp/LiftFileCheckerApp.csproj
+++ b/src/LiftFileCheckerApp/LiftFileCheckerApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridge-ChorusPlugin.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NetSparkle.Net40" Version="1.2.0" />
-    <PackageReference Include="SIL.Chorus.App" Version="5.0.0-*" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.App" Version="$(ChorusVersion)" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.FLExBridge.IPCFramework" Version="1.1.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
+++ b/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="5.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- The old code was un-intentionally using the 5.0.0-netcore0102
nuget package.

- Created a property for the version and use it in the .csproj
files.

- Similar changes were also made for LCM. Use LCM 10.2.0-beta*
nuget packages instead of 10.2.0-*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/368)
<!-- Reviewable:end -->
