### PR TITLE
Add explicit reference to Mono.Unix

### DIFF
--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="all" />
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.LCModel.Utils" Version="$(LCModelVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />


### PR DESCRIPTION
This is necessary so that the unmanaged binaries in `runtimes` get copied to the output directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/370)
<!-- Reviewable:end -->
