### PR TITLE
Re-add .NET Standard 2.0 to framework targets…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [3.8.1] - 2022-08-26
-
 ### Added
 
 - Add .NET Standard to LfMergeBridge, LibFLExBridge-ChorusPlugin, and LibTriboroughBridge-ChorusPlugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.6.4] - 2022-08-26
+
+### Added
+
+- Add .NET Standard to LfMergeBridge, LibFLExBridge-ChorusPlugin, and LibTriboroughBridge-ChorusPlugin
+
 ## [3.6.3] - 2022-07-29
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
 	<ChangelogFile>../../CHANGELOG.md</ChangelogFile>
 	<UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-	<ChorusVersion>5.0.0-beta*</ChorusVersion>
+	<ChorusVersion>5.0.1-beta*</ChorusVersion>
 	<LCModelVersion>10.2.0-beta*</LCModelVersion>
   </PropertyGroup>
 </Project>

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>LfMergeBridge</RootNamespace>
     <AssemblyTitle>LfMergeBridge</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LfMergeBridge</PackageId>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>LibFLExBridgeChorusPlugin</RootNamespace>
     <AssemblyTitle>LibFLExBridge-ChorusPlugin</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LibFLExBridge</PackageId>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>LibTriboroughBridgeChorusPlugin</RootNamespace>
     <AssemblyTitle>LibTriboroughBridge-ChorusPlugin</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LibTriboroughBridge</PackageId>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
     <PackageReference Include="SIL.Chorus.LibChorus" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.LCModel.Utils" Version="$(LCModelVersion)" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…for the projects used by LFMerge.

Also reference Win32.Registry in LibTriboroughBridge-ChorusPlugin to fix a pretty ugly build warning about version conflicts.

This reverts commit d00ed11f584e81ebf8f2c2fe7670bd7f83114180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/372)
<!-- Reviewable:end -->
