### PR TITLE
Fix Unit Tests

### DIFF
--- a/FLExBridge.sln
+++ b/FLExBridge.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31424.327
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33122.133
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OtherDocs", "OtherDocs", "{0D38A3A9-1AE9-4984-A412-D395D2666ECC}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,8 +9,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OtherDocs", "OtherDocs", "{
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		DistFiles\about.htm = DistFiles\about.htm
+		src\AppForTests.config = src\AppForTests.config
 		appveyor.yml = appveyor.yml
 		CHANGELOG.md = CHANGELOG.md
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		build\FLExBridge.proj = build\FLExBridge.proj
 		GitVersion.yml = GitVersion.yml
 		src\Installer\Installer.wixproj = src\Installer\Installer.wixproj

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -35,8 +35,7 @@ FLEx Bridge depends on several assemblies from Chorus and Palaso. Those are inst
 
 ### Build
 
-You should be able to build solution `FLExBridge.sln` from Visual Studio 2019 Community Edition or
-JetBrains Rider.
+You should be able to build solution `FLExBridge.sln` from Visual Studio 2022 Community Edition or JetBrains Rider.
 
 You can also build and run tests on both Windows and Linux from the command line by running:
 

--- a/src/AppForTests.config
+++ b/src/AppForTests.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="L10NSharp" publicKeyToken="fd0b3e309a5b7c28" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
+++ b/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>FLEx-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for FLEx-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <AppConfig>..\AppForTests.config</AppConfig>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FLEx-ChorusPluginTests/Integration/MergeIntegrationTests.cs
+++ b/src/FLEx-ChorusPluginTests/Integration/MergeIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.IO;
@@ -160,7 +160,8 @@ namespace FLEx_ChorusPluginTests.Integration
 					var mergeConflictsNotesFile = ChorusNotesMergeEventListener.GetChorusNotesFilePath(randyRepo.UserFile.Path);
 					Assert.That(File.Exists(mergeConflictsNotesFile), Is.False, "ChorusNotes file should NOT have been in working set.");
 					randyRepo.WriteNewContentsToTestFile(randy);
-					randyRepo.CheckinAndPullAndMerge(sueRepo);
+					var result = randyRepo.CheckinAndPullAndMerge(sueRepo);
+					Assert.That(result.Succeeded, result.ErrorEncountered?.ToString());
 					Assert.That(File.Exists(mergeConflictsNotesFile), Is.True, "ChorusNotes file should have been in working set.");
 					var notesContents = File.ReadAllText(mergeConflictsNotesFile);
 					Assert.That(notesContents, Is.Not.Null.Or.Empty);
@@ -263,7 +264,8 @@ namespace FLEx_ChorusPluginTests.Integration
 					var mergeConflictsNotesFile = ChorusNotesMergeEventListener.GetChorusNotesFilePath(randyRepo.UserFile.Path);
 					Assert.That(File.Exists(mergeConflictsNotesFile), Is.False, "ChorusNotes file should NOT have been in working set.");
 					randyRepo.WriteNewContentsToTestFile(randy);
-					randyRepo.CheckinAndPullAndMerge(sueRepo);
+					var result = randyRepo.CheckinAndPullAndMerge(sueRepo);
+					Assert.That(result.Succeeded, result.ErrorEncountered?.ToString());
 					Assert.That(File.Exists(mergeConflictsNotesFile), Is.True, "ChorusNotes file should have been in working set.");
 					var notesContents = File.ReadAllText(mergeConflictsNotesFile);
 					Assert.That(notesContents, Is.Not.Null.Or.Empty);
@@ -354,7 +356,8 @@ namespace FLEx_ChorusPluginTests.Integration
 						var mergeConflictsNotesFile = ChorusNotesMergeEventListener.GetChorusNotesFilePath(randyDictConfigInRepoPath);
 						Assert.That(File.Exists(mergeConflictsNotesFile), Is.False, "ChorusNotes file should NOT have been in working set.");
 						randyRepo.AddAndCheckinFile($"root.{FlexBridgeConstants.fwdictconfig}", randy);
-						randyRepo.CheckinAndPullAndMerge(sueRepo);
+						var result = randyRepo.CheckinAndPullAndMerge(sueRepo);
+						Assert.That(result.Succeeded, result.ErrorEncountered?.ToString());
 						Assert.That(File.Exists(mergeConflictsNotesFile), Is.True, "ChorusNotes file should have been in working set.");
 						var notesContents = File.ReadAllText(mergeConflictsNotesFile);
 						Assert.That(notesContents, Is.Not.Null.Or.Empty);

--- a/src/FLExBridge/FLExBridge.csproj
+++ b/src/FLExBridge/FLExBridge.csproj
@@ -18,4 +18,11 @@
     <ProjectReference Include="..\TriboroughBridge-ChorusPlugin\TriboroughBridge-ChorusPlugin.csproj" />
   </ItemGroup>
 
+  <Target Name="MakeChorusMergeExeConfig" AfterTargets="CopyFilesToOutputDirectory">
+    <PropertyGroup>
+      <FLExBridgeExeConfig>$(OutputPath)/$(AssemblyTitle).exe.config</FLExBridgeExeConfig>
+      <ChorusMergeExeConfig>$(OutputPath)/ChorusMerge.exe.config</ChorusMergeExeConfig>
+    </PropertyGroup>
+    <Copy SourceFiles="$(FLExBridgeExeConfig)" DestinationFiles="$(ChorusMergeExeConfig)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>LibFLExBridge-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for LibFLExBridge-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <AppConfig>..\AppForTests.config</AppConfig>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mysterious dependency updates broke unit tests.
* Make tests look for the shipping versions of dependencies.
* Make MergeIntegrationTests return a helpful error when Chorus reports a failure.
* Upgrade to Visual Studio 2022 (.sln and ReadMe)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/376)
<!-- Reviewable:end -->
