### PR TITLE
[API] Add -uri option to obtain a specific project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Command to clone a specific project
+
 ### Removed
 
 - Command to check for Updates

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
 	<ChangelogFile>../../CHANGELOG.md</ChangelogFile>
 	<UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-	<ChorusVersion>5.2.0-beta*</ChorusVersion>
+	<ChorusVersion>6.0.0-beta*</ChorusVersion>
 	<LCModelVersion>10.2.0-beta*</LCModelVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/ObtainProjectStrategyFlex.cs
+++ b/src/FLEx-ChorusPlugin/Infrastructure/ActionHandlers/ObtainProjectStrategyFlex.cs
@@ -26,7 +26,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 		[Import]
 		private FLExConnectionHelper _connectionHelper;
 #pragma warning restore 0649
-		private bool _gotClone;
+		private bool GotClone { get { return _newFwProjectPathname != null;}}
 		private string _newProjectFilename;
 		private string _newFwProjectPathname;
 
@@ -61,12 +61,17 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 
 			_newProjectFilename = Path.GetFileName(cloneLocation) + LibTriboroughBridgeSharedConstants.FwXmlExtension;
 			_newFwProjectPathname = Path.Combine(cloneLocation, _newProjectFilename);
+			
+			if (File.Exists(_newFwProjectPathname))
+			{
+				// .fwdata already exists
+				return;
+			}
 
 			// Check the actual FW model number in the '-fwmodel' of 'commandLineArgs' param.
 			// Update to the head of the desired branch, if possible.
 			UpdateToTheCorrectBranchHeadIfPossible(commandLineArgs, actualCloneResult, cloneLocation);
 
-			_gotClone = false;
 			switch (actualCloneResult.FinalCloneResult)
 			{
 				case FinalCloneResult.ExistingCloneTargetFolder:
@@ -80,8 +85,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 					Directory.Delete(cloneLocation, true);
 					_newFwProjectPathname = null;
 					return;
-                case FinalCloneResult.Cloned:
-					_gotClone = true;
+        case FinalCloneResult.Cloned:
 					break;
 			}
 
@@ -90,7 +94,7 @@ namespace FLEx_ChorusPlugin.Infrastructure.ActionHandlers
 
 		void IObtainProjectStrategy.TellFlexAboutIt()
 		{
-			if (_gotClone)
+			if (GotClone)
 			{
 				_connectionHelper.CreateProjectFromFlex(_newFwProjectPathname);
 			}

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2023 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -29,7 +29,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string pipeID = "-pipeID";
 		internal const string locale = "-locale";
 		internal const string uri = "-uri"; // Full project URI
-		internal const string project = "-project"; // Project name
+		internal const string project = "-project"; // Local project name for cloning
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -17,7 +17,7 @@ namespace TriboroughBridge_ChorusPlugin
 	internal static class CommandLineProcessor
 	{
 // ReSharper disable InconsistentNaming
-		internal const string u = "-u"; // userNameActual
+		internal const string u = "-u"; // the name to use in the commit log
 		internal const string p = "-p"; // project directory
 		internal const string v = "-v"; // command
 		internal const string f = "-f"; // FixItAppPathname
@@ -28,9 +28,8 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string liftmodel = "-liftmodel"; // LIFT model version number
 		internal const string pipeID = "-pipeID";
 		internal const string locale = "-locale";
-		internal const string uri = "-uri";
-		internal const string project = "-project";
-		internal const string user = "-user";
+		internal const string uri = "-uri"; // Full project URI
+		internal const string project = "-project"; // Project name
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -29,7 +29,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string pipeID = "-pipeID";
 		internal const string locale = "-locale";
 		internal const string uri = "-uri"; // Full project URI
-		internal const string project = "-project"; // Local project name for cloning
+		internal const string project = "-project"; // Project name to clone into
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -30,6 +30,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string locale = "-locale";
 		internal const string uri = "-uri"; // Full project URI
 		internal const string project = "-project"; // Project name to clone into
+		internal const string repositoryIdentifier = "-repositoryIdentifier"; // Identifier to match projects across repo's
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -29,6 +29,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string pipeID = "-pipeID";
 		internal const string locale = "-locale";
 		internal const string uri = "-uri";
+		internal const string project = "-project";
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -28,6 +28,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string liftmodel = "-liftmodel"; // LIFT model version number
 		internal const string pipeID = "-pipeID";
 		internal const string locale = "-locale";
+		internal const string uri = "-uri";
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
+++ b/src/TriboroughBridge-ChorusPlugin/CommandLineProcessor.cs
@@ -30,6 +30,7 @@ namespace TriboroughBridge_ChorusPlugin
 		internal const string locale = "-locale";
 		internal const string uri = "-uri";
 		internal const string project = "-project";
+		internal const string user = "-user";
 
 		internal const string obtain = "obtain";						// -p <$fwroot>
 		internal const string obtain_lift = "obtain_lift";				// -p <$fwroot>\foo where 'foo' is the project folder name

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -145,7 +145,10 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 		private CloneResult Clone(string projectArg, string uriArg)
 		{
 			var credentials = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS");
-			if (credentials == null || !credentials.Contains(":")) return new CloneResult(null, CloneStatus.NotCreated);
+			if (credentials == null || !credentials.Contains(":"))
+			{
+				return new CloneResult(null, CloneStatus.NotCreated);
+			}
 			var split = credentials.Split(new[] {':'}, 2);
 			var user = split[0];
 			var pass = split[1];

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2023 SIL International
+﻿// Copyright (c) 2010-2023 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -114,11 +114,13 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 
 		private CloneResult Clone(string projectArg, string uriArg)
 		{
-			var uri = new Uri(uriArg);
-			var credentials = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS").Split(new[] {':'}, 2);
-			var user = credentials[0];
-			var pass = credentials[1];
-			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uri);
+			var credentials = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS");
+			if (credentials == null || !credentials.Contains(":")) return new CloneResult(null, CloneStatus.NotCreated);
+			var split = credentials.Split(new[] {':'}, 2);
+			var user = split[0];
+			var pass = split[1];
+			var isJwt = user == "bearer";
+			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uriArg, !isJwt);
 		}
 
 		/// <summary>

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -78,10 +78,9 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			CloneResult result;
 			var uriArg = options[CommandLineProcessor.uri];
 			var projectArg = options[CommandLineProcessor.project];
-			var userArg = options[CommandLineProcessor.user];
-			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg) && !string.IsNullOrEmpty(userArg))
+			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg))
 			{
-				result = Clone(projectArg, uriArg, userArg);
+				result = Clone(projectArg, uriArg);
 			}
 			else
 			{
@@ -113,15 +112,17 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			_currentStrategy.FinishCloning(options, result.ActualLocation, null);
 		}
 
-		private CloneResult Clone(string projectArg, string uriArg, string userArg)
+		private CloneResult Clone(string projectArg, string uriArg)
 		{
 			var uri = new Uri(uriArg);
-			var jwt = Environment.GetEnvironmentVariable("JWT");
+			var userpass = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS");
+			var user = userpass.Split(':')[0];
+			var pass = userpass.Split(':')[1];
 			var host = new Uri(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
 
 			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
 
-			return GetCloneFromInternetDialog.DoClone(userArg, jwt, _pathToRepository, projectArg, uri);
+			return GetCloneFromInternetDialog.DoClone(user, pass, _pathToRepository, projectArg, uri);
 		}
 
 		/// <summary>

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -78,9 +78,10 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			CloneResult result;
 			var uriArg = options[CommandLineProcessor.uri];
 			var projectArg = options[CommandLineProcessor.project];
-			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg))
+			var userArg = options[CommandLineProcessor.user];
+			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg) && !string.IsNullOrEmpty(userArg))
 			{
-				result = StartClone(projectArg, uriArg);
+				result = StartClone(projectArg, uriArg, userArg);
 			}
 			else
 			{
@@ -112,7 +113,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			_currentStrategy.FinishCloning(options, result.ActualLocation, null);
 		}
 
-		private CloneResult StartClone(string projectArg, string uriArg)
+		private CloneResult StartClone(string projectArg, string uriArg, string userArg)
 		{
 			var uri = new Uri(uriArg);
 			var jwt = Environment.GetEnvironmentVariable("JWT");
@@ -120,7 +121,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 
 			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
 
-			var dialog = GetCloneFromInternetDialog.StartClone("bearer", jwt, _pathToRepository, projectArg, uri);
+			var dialog = GetCloneFromInternetDialog.StartClone(userArg, jwt, _pathToRepository, projectArg, uri);
 			DialogResult? res = null;
 			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
 			Application.Run(dialog);

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -120,11 +120,9 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 
 			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
 
-			var dialog = new GetCloneFromInternetDialog(_pathToRepository);
+			var dialog = GetCloneFromInternetDialog.StartClone("bearer", jwt, _pathToRepository, projectArg, uri);
 			DialogResult? res = null;
 			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
-			dialog.Show();
-			dialog.StartClone("bearer", jwt, projectArg, uri);
 			Application.Run(dialog);
 
 			var cloneStatus = res == DialogResult.OK ? CloneStatus.Created : CloneStatus.NotCreated;

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -77,9 +77,10 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			_pathToRepository = options[CommandLineProcessor.projDir];
 			CloneResult result;
 			var uriArg = options[CommandLineProcessor.uri];
-			if (!string.IsNullOrEmpty(uriArg))
+			var projectArg = options[CommandLineProcessor.project];
+			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg))
 			{
-				result = StartClone(uriArg);
+				result = StartClone(projectArg, uriArg);
 			}
 			else
 			{
@@ -111,20 +112,19 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			_currentStrategy.FinishCloning(options, result.ActualLocation, null);
 		}
 
-		private CloneResult StartClone(string uriArg)
+		private CloneResult StartClone(string projectArg, string uriArg)
 		{
 			var uri = new Uri(uriArg);
 			var jwt = Environment.GetEnvironmentVariable("JWT");
 			var host = new Uri(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
-			var projectName = uri.Segments[1];
 
-			if (MessageBox.Show($"Download {projectName} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
+			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
 
 			var dialog = new GetCloneFromInternetDialog(_pathToRepository);
 			DialogResult? res = null;
 			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
 			dialog.Show();
-			dialog.StartClone("bearer", jwt, host, projectName);
+			dialog.StartClone("bearer", jwt, projectArg, uri);
 			Application.Run(dialog);
 
 			var cloneStatus = res == DialogResult.OK ? CloneStatus.Created : CloneStatus.NotCreated;

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -120,7 +120,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			var user = split[0];
 			var pass = split[1];
 			//Accepted practice for authenticating with JWT (https://github.com/sillsdev/languageforge-lexbox/issues/242)
-			//Per param name saveUserSettings, we don't want to overwrite user/pass setting if with bearer/JWT
+			//Per param name saveUserSettings, we don't want to overwrite user/pass setting if bearer/JWT
 			var isJwt = user == "bearer";
 			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uriArg, !isJwt);
 		}

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -81,7 +81,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			var userArg = options[CommandLineProcessor.user];
 			if (!string.IsNullOrEmpty(uriArg) && !string.IsNullOrEmpty(projectArg) && !string.IsNullOrEmpty(userArg))
 			{
-				result = StartClone(projectArg, uriArg, userArg);
+				result = Clone(projectArg, uriArg, userArg);
 			}
 			else
 			{
@@ -113,7 +113,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			_currentStrategy.FinishCloning(options, result.ActualLocation, null);
 		}
 
-		private CloneResult StartClone(string projectArg, string uriArg, string userArg)
+		private CloneResult Clone(string projectArg, string uriArg, string userArg)
 		{
 			var uri = new Uri(uriArg);
 			var jwt = Environment.GetEnvironmentVariable("JWT");
@@ -121,13 +121,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 
 			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
 
-			var dialog = GetCloneFromInternetDialog.StartClone(userArg, jwt, _pathToRepository, projectArg, uri);
-			DialogResult? res = null;
-			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
-			Application.Run(dialog);
-
-			var cloneStatus = res == DialogResult.OK ? CloneStatus.Created : CloneStatus.NotCreated;
-			return new CloneResult(dialog.PathToNewlyClonedFolder, cloneStatus);
+			return GetCloneFromInternetDialog.DoClone(userArg, jwt, _pathToRepository, projectArg, uri);
 		}
 
 		/// <summary>

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2023 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -115,14 +115,10 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 		private CloneResult Clone(string projectArg, string uriArg)
 		{
 			var uri = new Uri(uriArg);
-			var userpass = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS");
-			var user = userpass.Split(':')[0];
-			var pass = userpass.Split(':')[1];
-			var host = new Uri(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
-
-			if (MessageBox.Show($"Download {projectArg} from {host}?", "Confirm Download", MessageBoxButtons.YesNo) != DialogResult.Yes) return null;
-
-			return GetCloneFromInternetDialog.DoClone(user, pass, _pathToRepository, projectArg, uri);
+			var credentials = Environment.GetEnvironmentVariable("CHORUS_CREDENTIALS").Split(new[] {':'}, 2);
+			var user = credentials[0];
+			var pass = credentials[1];
+			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uri);
 		}
 
 		/// <summary>

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -119,6 +119,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			var split = credentials.Split(new[] {':'}, 2);
 			var user = split[0];
 			var pass = split[1];
+			//Accepted practice for authenticating with JWT (https://github.com/sillsdev/languageforge-lexbox/issues/242)
 			var isJwt = user == "bearer";
 			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uriArg, !isJwt);
 		}

--- a/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
+++ b/src/TriboroughBridge-ChorusPlugin/Infrastructure/ActionHandlers/ObtainAnyProjectActionHandler.cs
@@ -120,6 +120,7 @@ namespace TriboroughBridge_ChorusPlugin.Infrastructure.ActionHandlers
 			var user = split[0];
 			var pass = split[1];
 			//Accepted practice for authenticating with JWT (https://github.com/sillsdev/languageforge-lexbox/issues/242)
+			//Per param name saveUserSettings, we don't want to overwrite user/pass setting if with bearer/JWT
 			var isJwt = user == "bearer";
 			return GetCloneFromInternetDialog.ConfirmAndDoClone(user, pass, _pathToRepository, projectArg, uriArg, !isJwt);
 		}


### PR DESCRIPTION
When given a -uri argument, the Obtain command will open the GetCloneFromInternetDialog and clone a new repo from the URI. I opted to expand this command over creating a new one, as it seemed a less intrusive and breaking change.

The URI is stripped of everything but its scheme, hostname, and project name (first segment). Further, a simple dialog box is shown on launch, confirming the download. These features help with security.

The operation returns a CloneResult, just like the "any project" operation, and will presumably proceed to open the new project.

The current design requires an environment variable to be set containing the JWT password. This allows us to avoid passing it through CMD to this process. It's recommended to instantiate the env var with scope limited to the process.

The JWT is coupled with the "bearer" username and therefore required. Other user/pass combinations are not supported.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/388)
<!-- Reviewable:end -->
