### PR TITLE
Add the restore step needed for GeneratePathProperty property

### DIFF
--- a/build/TestInstallerBuild.bat
+++ b/build/TestInstallerBuild.bat
@@ -19,6 +19,8 @@ pushd .
 ) && (
 	pushd ..\l10n
 ) && (
+	MSBuild l10n.proj /t:restore
+) && (
 	MSBuild l10n.proj /t:GetLatestL10ns
 ) && (
 	popd


### PR DESCRIPTION
* Without the initial restore the l10n.proj doesn't pick up the path property and can't find MSBuild.ExtensionPack.dll

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/395)
<!-- Reviewable:end -->
