### PR TITLE
Expose PutHumptyTogetherAgain method in LfMergeBridge

### DIFF
--- a/src/LfMergeBridge/LfMergeBridge.cs
+++ b/src/LfMergeBridge/LfMergeBridge.cs
@@ -71,5 +71,10 @@ namespace LfMergeBridge
 
 			return true;
 		}
+
+		public static void PutHumptyTogetherAgain(IProgress progress, bool writeVerbose, string mainFilePathname)
+		{
+			LibFLExBridgeChorusPlugin.DomainServices.FLExProjectUnifier.PutHumptyTogetherAgain(progress, writeVerbose, mainFilePathname);
+		}
 	}
 }

--- a/src/LfMergeBridge/LfMergeBridge.cs
+++ b/src/LfMergeBridge/LfMergeBridge.cs
@@ -72,7 +72,12 @@ namespace LfMergeBridge
 			return true;
 		}
 
-		public static void PutHumptyTogetherAgain(IProgress progress, bool writeVerbose, string mainFilePathname)
+		public static void DisassembleFwdataFile(IProgress progress, bool writeVerbose, string mainFilePathname)
+		{
+			LibFLExBridgeChorusPlugin.DomainServices.FLExProjectSplitter.PushHumptyOffTheWall(progress, writeVerbose, mainFilePathname);
+		}
+
+		public static void ReassembleFwdataFile(IProgress progress, bool writeVerbose, string mainFilePathname)
 		{
 			LibFLExBridgeChorusPlugin.DomainServices.FLExProjectUnifier.PutHumptyTogetherAgain(progress, writeVerbose, mainFilePathname);
 		}


### PR DESCRIPTION
The LexBox project wants to be able to [generate .fwdata files on the fly](https://github.com/sillsdev/languageforge-lexbox/issues/631), which will enable various features such as being able to view recent changes to a project in a nicer form than Mercurial diffs. In order to make this work, we need to expose the PutHumptyTogetherAgain method as a public method.

This PR seems the simplest way to do it, enabling access to that API from LfMergeBridge without changing the access granted to any other projects. That way we minimize the risk to FLEx and WeSay, as the code they use is not touched at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/398)
<!-- Reviewable:end -->
