### PR TITLE
Update AppVeyor to use Visual Studio 2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 branches:
   only:
   - develop
-image: Visual Studio 2019
+image: Visual Studio 2022
 init:
   - cmd: |
       set GITVERSION_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER%


### PR DESCRIPTION
This will allow AppVeyor builds to handle code that targets .NET 8.

https://ci.appveyor.com/project/SIL_Language_Technology/flexbridge/builds/50111277 is an example build (from PR #403); the only change needed was updating the Visual Studio 2019 image to 2022.

Fixes #406.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/407)
<!-- Reviewable:end -->
