### PR TITLE
update net462

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,18 +30,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-
-      - name: Download 461 targeting pack
-        uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 # 1.6.0
-        id: downloadfile
-        with:
-            url: "https://download.microsoft.com/download/F/1/D/F1DEB8DB-D277-4EF9-9F48-3A65D4D8F965/NDP461-DevPack-KB3105179-ENU.exe"
-            target: public/
-
-      - name: Install targeting pack
-        shell: cmd
-        working-directory: public
-        run: NDP461-DevPack-KB3105179-ENU.exe /q
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 
@@ -58,7 +46,7 @@ jobs:
           choco uninstall wixtoolset
           choco install wixtoolset --version 3.11.2 --allow-downgrade --force
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        if: github.event_name != 'pull_request' 
+        if: github.event_name != 'pull_request'
 
       # If we are just doing a CI build we don't need real localizations, but the location must exist
       - name: Add Fake Localizations for CI
@@ -180,13 +168,13 @@ jobs:
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
-        
+
       - name: Download FlexBridge artifact
         uses: actions/download-artifact@v4
         with:
           name: FlexBridge.msi
           path: src/WiXInstaller/BaseInstallerBuild  # Target directory for the downloaded artifact
-        
+
       - name: Build Bundles
         id: build_bundles
         working-directory: build
@@ -194,7 +182,7 @@ jobs:
         run: |
           msbuild FLExBridge.proj /t:RestoreBuildTasks;RestorePackages;GetDotNetFiles;CopyWixOverrides
           msbuild FLExBridge.proj /t:BuildProductBaseBundles /p:Configuration=Release /p:Platform="Any CPU"
-      
+
       - name: Extract burn engines
         id: extract_engines
         working-directory: BuildDir
@@ -202,7 +190,7 @@ jobs:
         run: |
           insignia -ib FlexBridge_Offline.exe -o offline-engine.exe
           insignia -ib FlexBridge_Online.exe -o online-engine.exe
-      
+
       - name: Upload Offline Engine
         id: upload-offline-engine
         uses: actions/upload-artifact@v4
@@ -211,8 +199,8 @@ jobs:
           path: BuildDir/offline-engine.exe
           if-no-files-found: error
           overwrite: true
-        if: github.event_name != 'pull_request'   
-        
+        if: github.event_name != 'pull_request'
+
       - name: Upload Offline Bundle(detatched)
         id: upload-offline-bundle
         uses: actions/upload-artifact@v4
@@ -221,8 +209,8 @@ jobs:
           path: BuildDir/FlexBridge_Offline.exe
           if-no-files-found: error
           overwrite: true
-        if: github.event_name != 'pull_request' 
-        
+        if: github.event_name != 'pull_request'
+
       - name: Upload Online Engine
         id: upload-online-engine
         uses: actions/upload-artifact@v4
@@ -231,8 +219,8 @@ jobs:
           path: BuildDir/online-engine.exe
           if-no-files-found: error
           overwrite: true
-        if: github.event_name != 'pull_request'   
-        
+        if: github.event_name != 'pull_request'
+
       - name: Upload Online Bundle(detached)
         id: upload-online-bundle
         uses: actions/upload-artifact@v4
@@ -242,7 +230,7 @@ jobs:
           if-no-files-found: error
           overwrite: true
         if: github.event_name != 'pull_request'
-        
+
   sign-offline-engine:
     name: Sign Offline Engine
     needs: build-bundles
@@ -268,13 +256,13 @@ jobs:
   reattach-engines:
     runs-on: windows-latest
     needs: [sign-offline-engine, sign-online-engine]
-    steps:      
+    steps:
       - name: Downgrade Wix Toolset - remove when runner has 3.14.2
         run: |
           choco uninstall wixtoolset
           choco install wixtoolset --version 3.11.2 --allow-downgrade --force
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          
+
       - name: Download signed online engine
         uses: actions/download-artifact@v4
         with:
@@ -291,7 +279,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: FlexBridge_Offline.exe
-          
+
       - name: Reattach Engines
         shell: cmd
         run: |
@@ -317,17 +305,17 @@ jobs:
           if-no-files-found: error
           overwrite: true
         if: github.event_name != 'pull_request'
-      
-      - name: Cleanup Offline Engine      
+
+      - name: Cleanup Offline Engine
         uses: geekyeggo/delete-artifact@v5
         with:
           name: offline-engine
-      
-      - name: Cleanup Online Engine      
+
+      - name: Cleanup Online Engine
         uses: geekyeggo/delete-artifact@v5
         with:
           name: online-engine
-        
+
   sign-offline-bundle:
     name: Sign Offline Bundle
     needs: reattach-engines

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-	<TargetFrameworks>net461</TargetFrameworks>
+	<TargetFrameworks>net462</TargetFrameworks>
 	<Configurations>Debug;Release</Configurations>
 	<Description>Library that allows multiple FieldWorks users to collaborate remotely (i.e., not necessarily connected by a local network).</Description>
 	<Company>SIL</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,11 +25,11 @@ See full changelog at https://github.com/sillsdev/flexbridge/blob/develop/CHANGE
 	<ChangelogFile>../../CHANGELOG.md</ChangelogFile>
 	<UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-	<ChorusVersion>6.0.0-beta*</ChorusVersion>
-	<LCModelVersion>10.2.0-beta*</LCModelVersion>
+	<ChorusVersion>6.0.0-beta0059</ChorusVersion>
+	<LCModelVersion>11.0.0-beta*</LCModelVersion>
   </PropertyGroup>
   <ItemGroup>
 	<!-- The only reason we depend directly on L10NSharp is because our dependencies can't agree which one they want -->
-	<PackageReference Include="L10NSharp" Version="6.0.0" />
+	<PackageReference Include="L10NSharp" Version="8.0.0-beta0005" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,7 @@
 			their presence prevents L10nSharp from extracting strings for localization, since the Linux Geckofx DLL's can't be loaded.
 			Deleting them here fixes both developer builds in Visual Studio and installer builds on the server. -->
 		<ItemGroup>
-			<GeckofxDlls Include="$(MSBuildThisFiledirectory)/output/$(Configuration)/net461/Geckofx-*"/>
+			<GeckofxDlls Include="$(MSBuildThisFiledirectory)/output/$(Configuration)/$(TargetFramework)/Geckofx-*"/>
 		</ItemGroup>
 		<Delete Files="@(GeckofxDlls)"/>
 	</Target>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,10 +28,10 @@ FLEx Bridge depends on several assemblies from Chorus and Palaso. Those are inst
 
   ```
   [HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\SIL\Flex Bridge\9]
-      "InstallationDir"="C:\Dev\flexbridge\output\Debug\net461"
+      "InstallationDir"="C:\Dev\flexbridge\output\Debug\net462"
   ```
 
-- On **Linux**, `export FLEXBRIDGEDIR=${HOME}/fwrepo/flexbridge/output/Debug/net461`
+- On **Linux**, `export FLEXBRIDGEDIR=${HOME}/fwrepo/flexbridge/output/Debug/net462`
 
 ### Build
 

--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -98,8 +98,8 @@
 	<Target Name="CreateDirectories">
 		<MakeDir Directories="$(RootDir)/output/"/>
 		<MakeDir Directories="$(RootDir)/output/$(Configuration)/"/>
-		<MakeDir Directories="$(RootDir)/output/$(Configuration)/net461/"/>
-		<MakeDir Directories="$(RootDir)/output/$(Configuration)/net461/localizations/"/>
+		<MakeDir Directories="$(RootDir)/output/$(Configuration)/$(TargetFramework)/"/>
+		<MakeDir Directories="$(RootDir)/output/$(Configuration)/$(TargetFramework)/localizations/"/>
 	</Target>
 
 	<ItemGroup>
@@ -109,23 +109,23 @@
 		<NDeskDBusFiles Include="$(RootDir)/lib/$(Configuration)/NDesk.DBus.dll*"/>
 		<ChorusHubFiles Include="$(RootDir)/lib/$(Configuration)/ChorusHub.*"/>
 		<ConfigFiles Include="$(RootDir)/lib/$(Configuration)/*.dll.config"/>
-		<GeckoBrowserFiles Include="$(RootDir)/packages/SIL.Windows.Forms.GeckoBrowserAdapter.$(PalasoVer4LinuxGecko)/lib/net461/SIL.Windows.Forms.GeckoBrowserAdapter.dll*"/>
+		<GeckoBrowserFiles Include="$(RootDir)/packages/SIL.Windows.Forms.GeckoBrowserAdapter.$(PalasoVer4LinuxGecko)/lib/$(TargetFramework)/SIL.Windows.Forms.GeckoBrowserAdapter.dll*"/>
 		<LinuxLauncherFiles Include="$(RootDir)/flexbridge"/>
 	</ItemGroup>
 
 	<Target Name="CopyExtraFilesToOutput" DependsOnTargets="CopyExtraFilesToOutputLinux">
 		<Error Text="Localization Files Missing" Condition="'@(LocalizeFiles)' == '' AND '$(Configuration)' != 'Debug'" />
-		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461/localizations"/>
+		<Copy SourceFiles="@(LocalizeFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)/localizations"/>
 	</Target>
 
 	<Target Name="CopyExtraFilesToOutputLinux" Condition="'$(OS)'!='Windows_NT'">
 		<Error Text="GeckoBrowserAdapter Missing" Condition="'@(GeckoBrowserFiles)' == ''" />
-		<Copy SourceFiles="@(LinuxLauncherFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(EnchantFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(ChorusHubFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
-		<Copy SourceFiles="@(GeckoBrowserFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
+		<Copy SourceFiles="@(LinuxLauncherFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
+		<Copy SourceFiles="@(EnchantFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
+		<Copy SourceFiles="@(NDeskDBusFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
+		<Copy SourceFiles="@(ChorusHubFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
+		<Copy SourceFiles="@(ConfigFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
+		<Copy SourceFiles="@(GeckoBrowserFiles)" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
 	</Target>
 
 	<Target Name="Compile" DependsOnTargets="CopyExtraFilesToOutput; RestorePackages">
@@ -133,7 +133,7 @@
 	</Target>
 
 	<Target Name="CopyAbout" DependsOnTargets="SetAssemblyVersion">
-		<Copy SourceFiles="$(RootDir)/output/Installer/about.htm" DestinationFolder="$(RootDir)/output/$(Configuration)/net461"/>
+		<Copy SourceFiles="$(RootDir)/output/Installer/about.htm" DestinationFolder="$(RootDir)/output/$(Configuration)/$(TargetFramework)"/>
 	</Target>
 
 	<Target Name="VersionNumbers" DependsOnTargets="RestoreBuildTasks;GetVersion" Condition="$(GetVersion)">
@@ -201,18 +201,18 @@
 
 	<Target Name="TestOnly" >
 		<ItemGroup>
-			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/net461/*Tests.dll" />
+			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/$(TargetFramework)/*Tests.dll" />
 		</ItemGroup>
 
 		<NUnit3 Assemblies="@(TestAssemblies)"
 			ToolPath="$(NUnitToolsDir)"
 			TestInNewThread="false"
 			ExcludeCategory="$(ExtraExcludeCategories)"
-			WorkingDirectory="$(RootDir)/output/$(Configuration)/net461"
+			WorkingDirectory="$(RootDir)/output/$(Configuration)/$(TargetFramework)"
 			Process="single"
 			Verbose="true"
 			UseNUnit3Xml="false"
-			OutputXmlFile="$(RootDir)/output/$(Configuration)/net461/TestResults.xml"
+			OutputXmlFile="$(RootDir)/output/$(Configuration)/$(TargetFramework)/TestResults.xml"
 			TeamCity="$(TeamCity)"/>
 	</Target>
 

--- a/build/FLExBridge.proj
+++ b/build/FLExBridge.proj
@@ -28,6 +28,8 @@
 		<WriteVersionInfoToBuildLog Condition="'$(WriteVersionInfoToBuildLog)' == ''">true</WriteVersionInfoToBuildLog>
 		<TeamCity Condition="'$(teamcity_version)' != ''">true</TeamCity>
 		<TeamCity Condition="'$(teamcity_version)' == ''">false</TeamCity>
+<!--		note this does not set the TargetFramework for the csproj files, it's just used as a variable to configure build paths-->
+		<TargetFramework Condition="'$(TargetFramework)' == ''">net462</TargetFramework>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildTasksTargets)" Condition="Exists('$(MSBuildTasksTargets)')"/>
@@ -199,7 +201,7 @@
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="TestOnly" Properties="Configuration=$(Configuration);GetVersion=$(GetVersion);WriteVersionInfoToBuildLog=$(WriteVersionInfoToBuildLog)" Condition="$(RestartBuild)" />
 	</Target>
 
-	<Target Name="TestOnly" >
+	<Target Name="TestOnly">
 		<ItemGroup>
 			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/$(TargetFramework)/*Tests.dll" />
 		</ItemGroup>

--- a/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
+++ b/src/FLEx-ChorusPluginTests/FLEx-ChorusPluginTests.csproj
@@ -5,12 +5,15 @@
     <AssemblyName>FLEx-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for FLEx-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <AppConfig>..\AppForTests.config</AppConfig>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>

--- a/src/LfMergeBridge/LfMergeBridge.csproj
+++ b/src/LfMergeBridge/LfMergeBridge.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>LfMergeBridge</RootNamespace>
     <AssemblyTitle>LfMergeBridge</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LfMergeBridge</PackageId>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
+++ b/src/LibFLExBridge-ChorusPlugin/LibFLExBridge-ChorusPlugin.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>LibFLExBridgeChorusPlugin</RootNamespace>
     <AssemblyTitle>LibFLExBridge-ChorusPlugin</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LibFLExBridge</PackageId>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 

--- a/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
+++ b/src/LibFLExBridge-ChorusPluginTests/LibFLExBridge-ChorusPluginTests.csproj
@@ -5,12 +5,15 @@
     <AssemblyName>LibFLExBridge-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for LibFLExBridge-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <AppConfig>..\AppForTests.config</AppConfig>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="6.*" IncludeAssets="build" />
   </ItemGroup>

--- a/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
+++ b/src/LibTriboroughBridge-ChorusPlugin/LibTriboroughBridge-ChorusPlugin.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>LibTriboroughBridgeChorusPlugin</RootNamespace>
     <AssemblyTitle>LibTriboroughBridge-ChorusPlugin</AssemblyTitle>
     <PackageId>SIL.ChorusPlugin.LibTriboroughBridge</PackageId>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LibTriboroughBridge-ChorusPluginTests/LibTriboroughBridge-ChorusPluginTests.csproj
+++ b/src/LibTriboroughBridge-ChorusPluginTests/LibTriboroughBridge-ChorusPluginTests.csproj
@@ -5,11 +5,14 @@
     <AssemblyName>TriboroughBridge-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for LibTriboroughBridge-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.LCModel.Utils.Tests" Version="$(LCModelVersion)" />
     <PackageReference Include="SIL.LCModel.Utils" Version="$(LCModelVersion)" />
   </ItemGroup>

--- a/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
+++ b/src/LiftBridge-ChorusPluginTests/LiftBridge-ChorusPluginTests.csproj
@@ -5,11 +5,14 @@
     <AssemblyName>LiftBridge-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for LiftBridge-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 

--- a/src/RepositoryUtilityTests/RepositoryUtilityTests.csproj
+++ b/src/RepositoryUtilityTests/RepositoryUtilityTests.csproj
@@ -3,10 +3,13 @@
   <PropertyGroup>
     <Description>Unit tests for the FLEx Bridge Repository Utility</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
+++ b/src/TriboroughBridge-ChorusPlugin/TriboroughBridgeUtilities.cs
@@ -101,9 +101,9 @@ namespace TriboroughBridge_ChorusPlugin
 				var versionObj = Assembly.GetExecutingAssembly().GetName().Version;
 				// We don't need to reload strings for every "revision" (that might be every time we build). REVIEW (Hasso) 2021.08: then why do we have `build`?
 				var version = $"{versionObj.Major}.{versionObj.Minor}.{versionObj.Build}";
-				var flexBridgeLocMan = LocalizationManager.Create(TranslationMemory.XLiff, desiredUiLangId, FlexBridge, Application.ProductName,
+				var flexBridgeLocMan = LocalizationManager.Create(desiredUiLangId, FlexBridge, Application.ProductName,
 					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus,
-					FlexLocalizationEmailAddress, FlexBridge, "TriboroughBridge_ChorusPlugin", "FLEx_ChorusPlugin", "SIL.LiftBridge");
+					FlexLocalizationEmailAddress, new [] { FlexBridge, "TriboroughBridge_ChorusPlugin", "FLEx_ChorusPlugin", "SIL.LiftBridge" });
 				results.Add("FlexBridge", flexBridgeLocMan);
 
 				// In case the UI language was unavailable, change it, so we don't frustrate the user with three dialogs.
@@ -111,14 +111,14 @@ namespace TriboroughBridge_ChorusPlugin
 
 				versionObj = Assembly.GetAssembly(typeof(ChorusSystem)).GetName().Version;
 				version = "" + versionObj.Major + "." + versionObj.Minor + "." + versionObj.Build;
-				var chorusLocMan = LocalizationManager.Create(TranslationMemory.XLiff, desiredUiLangId, "Chorus", "Chorus",
-					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, "Chorus");
+				var chorusLocMan = LocalizationManager.Create(desiredUiLangId, "Chorus", "Chorus",
+					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, new []{ "Chorus" });
 				results.Add("Chorus", chorusLocMan);
 
 				versionObj = Assembly.GetAssembly(typeof(ErrorReport)).GetName().Version;
 				version = "" + versionObj.Major + "." + versionObj.Minor + "." + versionObj.Build;
-				var palasoLocMan = LocalizationManager.Create(TranslationMemory.XLiff, desiredUiLangId, "Palaso", "Palaso",
-					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, "SIL");
+				var palasoLocMan = LocalizationManager.Create(desiredUiLangId, "Palaso", "Palaso",
+					version, installedL10nBaseDir, userL10nBaseDir, CommonResources.chorus, FlexLocalizationEmailAddress, new []{ "SIL" });
 				results.Add("Palaso", palasoLocMan);
 			}
 			catch (Exception e)

--- a/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
+++ b/src/TriboroughBridge-ChorusPluginTests/TriboroughBridge-ChorusPluginTests.csproj
@@ -5,11 +5,14 @@
     <AssemblyName>TriboroughBridge-ChorusPluginTests</AssemblyName>
     <Description>Unit tests for TriboroughBridge-ChorusPlugin</Description>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="all" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.Chorus.LibChorus.TestUtilities" Version="$(ChorusVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
this does not include a new Chorus version, nor does this upgrade other packages.

It does enable tests to be run via `dotnet test` though I ran into some test failures there (I believe they are caused by the different test environment though). When running via Rider all the tests pass. When running msbuild test, there's no failure, but there is this warning 
```
 warning : NUnit3 (FLEx-ChorusPluginTests LfMergeBridgeTests LibFLExBridge-ChorusPluginTests LiftBridge-ChorusPluginTests RepositoryUtilityTests SIL.LCModel.Utils.Tests TriboroughBridge-ChorusPluginTests) returned with exit code 15
 ```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/411)
<!-- Reviewable:end -->
