### PR TITLE
Fix LT-21388: Prserve 'xml' namespace on attributes while merging

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/DomainServices/FileWriterService.cs
+++ b/src/LibFLExBridge-ChorusPlugin/DomainServices/FileWriterService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2016 SIL International
+// Copyright (c) 2010-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -21,7 +21,7 @@ namespace LibFLExBridgeChorusPlugin.DomainServices
 		{
 			using (var writer = XmlWriter.Create(newPathname, CanonicalXmlSettings.CreateXmlWriterSettings()))
 			{
-				XmlUtils.WriteNode(writer, root.OuterXml, new HashSet<string>());
+				XmlUtils.WriteNode(writer, root.OuterXml, new HashSet<string>(), new HashSet<string> { "xml" });
 			}
 		}
 


### PR DESCRIPTION
* This will keep the spaces from being dropped

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/414)
<!-- Reviewable:end -->
