### PR TITLE
Update LfMergeBridge tests to new comments API

### DIFF
--- a/src/LfMergeBridgeTests/LanguageForgeGetChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeGetChorusNotesActionHandlerTests.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2018 SIL International
+// Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
 using System.IO;
 using LfMergeBridge;
+using LfMergeBridge.LfMergeModel;
 using LibTriboroughBridgeChorusPlugin.Infrastructure;
 using NUnit.Framework;
 using SIL.IO;
@@ -37,11 +38,12 @@ namespace LfMergeBridgeTests
 			return sutActionHandler;
 		}
 
-		private Dictionary<string, string> GetOptions(string projectDir)
+		private Dictionary<string, string> GetOptions(string projectDir, List<LfComment> commentsFromLfMerge)
 		{
 			var options = new Dictionary<string, string>();
-			options[LfMergeBridgeUtilities.serializedCommentsFromLfMerge] = _inputFile.Path;
 			options["-p"] = projectDir;
+			var extraInputData = new GetChorusNotesInput { LfComments = commentsFromLfMerge };
+			LfMergeBridge.LfMergeBridge.ExtraInputData.Add(options, extraInputData);
 			return options;
 		}
 
@@ -69,6 +71,36 @@ namespace LfMergeBridgeTests
 				"\"Replies\":[],\"IsDeleted\":false,\"ContextGuid\":null}}]\n" +
 				"New replies on comments already in LF: []\n" +
 				"New status changes on comments already in LF: []", status, statusGuid, DateTimeProvider.Current.Now.ToString("yyyy-MM-ddTHH:mm:sszzz")));
+		}
+
+		private static GetChorusNotesResponse ExpectValidResponse(Dictionary<string, string> options)
+		{
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as GetChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			return response;
+		}
+
+		private static void ExpectStatusChanges(Dictionary<string, string> options, string status, string statusGuid)
+		{
+			var response = ExpectValidResponse(options);
+			Assert.That(response.LfComments.Count, Is.EqualTo(0));
+			Assert.That(response.LfReplies.Count, Is.EqualTo(0));
+			Assert.That(response.LfStatusChanges.Count, Is.GreaterThan(0));
+			var change = response.LfStatusChanges[0];
+			Assert.That(change.Key, Is.EqualTo("e8a03b36-2c36-4647-b879-24dbcd5a9ac4"));
+			Assert.That(change.Value.Item1, Is.EqualTo(status));
+			Assert.That(change.Value.Item2, Is.EqualTo(statusGuid));
+		}
+
+		private static void ExpectNoStatusChanges(Dictionary<string, string> options)
+		{
+			var response = ExpectValidResponse(options);
+			Assert.That(response.LfComments.Count, Is.EqualTo(0));
+			Assert.That(response.LfReplies.Count, Is.EqualTo(0));
+			Assert.That(response.LfStatusChanges.Count, Is.EqualTo(0));
 		}
 
 		[SetUp]
@@ -105,19 +137,17 @@ namespace LfMergeBridgeTests
 					date=""2018-01-31T17:43:30Z""
 					guid=""c4f4df11-8dda-418e-8124-66406d67a2d1"">LF comment on F</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList(
-				"\"Status\":\"open\",\"StatusGuid\":\"c4f4df11-8dda-418e-8124-66406d67a2d1\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", "c4f4df11-8dda-418e-8124-66406d67a2d1");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedClientString(
-				"New comments not yet in LF: []\nNew replies on comments already in LF: []\n" +
-				"New status changes on comments already in LF: []")));
+			ExpectNoStatusChanges(options);
 		}
 
 		/// <summary>
@@ -141,18 +171,17 @@ namespace LfMergeBridgeTests
 					guid=""c9bd2519-b92a-4e65-a879-00e0c8a57e1d"">
 				</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList(string.Format(
-				"\"Status\":\"open\",\"StatusGuid\":\"{0}\",", statusGuid));
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", statusGuid);
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedStatusChangesMessage(
-				"resolved", "c9bd2519-b92a-4e65-a879-00e0c8a57e1d")));
+			ExpectStatusChanges(options, "resolved", "c9bd2519-b92a-4e65-a879-00e0c8a57e1d");
 		}
 
 		/// <summary>
@@ -182,17 +211,17 @@ namespace LfMergeBridgeTests
 					guid=""51b1ba75-b28a-4dac-9bb4-7f1e2f14563a"">
 				</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList("\"Status\":\"closed\",\"StatusGuid\":\"c9bd2519-b92a-4e65-a879-00e0c8a57e1d\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("closed", "c9bd2519-b92a-4e65-a879-00e0c8a57e1d");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedStatusChangesMessage(
-				"open", "51b1ba75-b28a-4dac-9bb4-7f1e2f14563a")));
+			ExpectStatusChanges(options, "open", "51b1ba75-b28a-4dac-9bb4-7f1e2f14563a");
 		}
 
 		/// <summary>
@@ -214,17 +243,17 @@ namespace LfMergeBridgeTests
 				status=""closed""
 				date=""2018-02-01T12:13:14Z""
 				guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>"));
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList("\"Status\":\"resolved\",\"StatusGuid\":\"c4f4df11-8dda-418e-8124-66406d67a2d1\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("resolved", "c4f4df11-8dda-418e-8124-66406d67a2d1");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedStatusChangesMessage(
-				"resolved", "1687b882-97c9-4ca0-9bc3-2a0511715400")));
+			ExpectStatusChanges(options, "resolved", "1687b882-97c9-4ca0-9bc3-2a0511715400");
 		}
 
 		/// <summary>
@@ -252,17 +281,17 @@ namespace LfMergeBridgeTests
 					status=""open""
 					date=""2018-02-01T12:13:14Z""
 					guid=""1687b882-97c9-4ca0-9bc3-2a0511715400""></message>"));
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList("\"Status\":\"open\",\"StatusGuid\":\"449489a4-8e0e-4b98-a75d-b6263f4a4e6a\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", "449489a4-8e0e-4b98-a75d-b6263f4a4e6a");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedStatusChangesMessage(
-				"open", "1687b882-97c9-4ca0-9bc3-2a0511715400")));
+			ExpectStatusChanges(options, "open", "1687b882-97c9-4ca0-9bc3-2a0511715400");
 		}
 
 		/// <summary>
@@ -281,17 +310,42 @@ namespace LfMergeBridgeTests
 					date=""{0}""
 					guid=""c4f4df11-8dda-418e-8124-66406d67a2d1"">LF comment on F</message>",
 				DateTimeProvider.Current.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))));
-			_inputFile = NotesTestHelper.CreateMongoDataFileAsList("\"Status\":\"open\",", false);
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", "", false);
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeGetChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(ExpectedNewCommentsMessage(
-				"open", "c4f4df11-8dda-418e-8124-66406d67a2d1")));
+			var response = ExpectValidResponse(options);
+			Assert.That(response.LfComments.Count, Is.EqualTo(1));
+			Assert.That(response.LfReplies.Count, Is.EqualTo(0));
+			Assert.That(response.LfStatusChanges.Count, Is.EqualTo(0));
+
+			var comment = response.LfComments[0];
+			Assert.That(comment.Guid, Is.EqualTo(new Guid("e8a03b36-2c36-4647-b879-24dbcd5a9ac4")));
+
+			Assert.That(comment.AuthorNameAlternate, Is.EqualTo("Language Forge"));
+			Assert.That(comment.Content, Is.EqualTo("LF comment on F"));
+			Assert.That(comment.ContextGuid, Is.Null);
+			Assert.That(comment.DateCreated, Is.EqualTo(DateTimeProvider.Current.Now));
+			Assert.That(comment.DateModified, Is.EqualTo(DateTimeProvider.Current.Now));
+			Assert.That(comment.IsDeleted, Is.False);
+			Assert.That(comment.Replies, Is.Empty);
+			Assert.That(comment.Status, Is.EqualTo("open"));
+			Assert.That(comment.StatusGuid, Is.EqualTo(new Guid("c4f4df11-8dda-418e-8124-66406d67a2d1")));
+
+			Assert.That(comment.Regarding.Field, Is.Null);
+			Assert.That(comment.Regarding.FieldNameForDisplay, Is.Null);
+			Assert.That(comment.Regarding.FieldValue, Is.Null);
+			Assert.That(comment.Regarding.InputSystem, Is.Null);
+			Assert.That(comment.Regarding.InputSystemAbbreviation, Is.Null);
+			Assert.That(comment.Regarding.Meaning, Is.EqualTo(""));
+			Assert.That(comment.Regarding.Word, Is.EqualTo("F"));
+			Assert.That(comment.Regarding.TargetGuid, Is.EqualTo("1e7a8774-da73-49de-83bf-a613c12bb281"));
 		}
 	}
 }

--- a/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
+++ b/src/LfMergeBridgeTests/LanguageForgeWriteToChorusNotesActionHandlerTests.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using LfMergeBridge;
+using LfMergeBridge.LfMergeModel;
 using LibTriboroughBridgeChorusPlugin.Infrastructure;
 using NUnit.Framework;
 using SIL.IO;
@@ -39,11 +41,12 @@ namespace LfMergeBridgeTests
 			return sutActionHandler;
 		}
 
-		private Dictionary<string, string> GetOptions(string projectDir)
+		private Dictionary<string, string> GetOptions(string projectDir, List<LfComment> commentsFromLfMerge, string key = "5a71f21c6efc676a612eb76f")
 		{
 			var options = new Dictionary<string, string>();
-			options[LfMergeBridgeUtilities.serializedCommentsFromLfMerge] = _inputFile.Path;
 			options["-p"] = projectDir;
+			var extraInputData = new WriteToChorusNotesInput { LfComments = commentsFromLfMerge.Select(cmt => new KeyValuePair<string, LfComment>(key, cmt)).ToList() };
+			LfMergeBridge.LfMergeBridge.ExtraInputData.Add(options, extraInputData);
 			return options;
 		}
 
@@ -84,18 +87,23 @@ namespace LfMergeBridgeTests
 					date=""2018-01-31T17:43:30Z""
 					guid=""c4f4df11-8dda-418e-8124-66406d67a2d1"">LF comment on F</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileById(string.Format(
-				"\"Status\":\"open\",\"StatusGuid\":\"{0}\",", statusGuid));
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", statusGuid);
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: {0}New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(0));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			AssertThatXmlIn.String(notesContent).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -121,17 +129,23 @@ namespace LfMergeBridgeTests
 					guid=""c9bd2519-b92a-4e65-a879-00e0c8a57e1d"">
 				</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileById(string.Format("\"Status\":\"open\",\"StatusGuid\":\"{0}\",", statusGuid));
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", statusGuid);
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: {0}New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(0));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			AssertThatXmlIn.String(notesContent).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -163,17 +177,23 @@ namespace LfMergeBridgeTests
 					guid=""51b1ba75-b28a-4dac-9bb4-7f1e2f14563a"">
 				</message>");
 			var projectDir = CreateTestProject(notesContent);
-			_inputFile = NotesTestHelper.CreateMongoDataFileById("\"Status\":\"closed\",\"StatusGuid\":\"c9bd2519-b92a-4e65-a879-00e0c8a57e1d\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("closed", "c9bd2519-b92a-4e65-a879-00e0c8a57e1d");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: {0}New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(0));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			AssertThatXmlIn.String(notesContent).EqualsIgnoreWhitespace(NotesTestHelper.ReadChorusNotesFile(projectDir));
 		}
 
@@ -192,17 +212,23 @@ namespace LfMergeBridgeTests
 				status=""open""
 				date=""2018-01-31T17:43:30Z""
 				guid=""c4f4df11-8dda-418e-8124-66406d67a2d1"">LF comment on F</message>"));
-			_inputFile = NotesTestHelper.CreateMongoDataFileById("\"Status\":\"resolved\",\"StatusGuid\":\"c4f4df11-8dda-418e-8124-66406d67a2d1\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("resolved", "c4f4df11-8dda-418e-8124-66406d67a2d1");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: {0}New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(0));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			AssertThatXmlIn.String(NotesTestHelper.GetAnnotationXml(
 @"		<message
 			author=""Language Forge""
@@ -237,17 +263,23 @@ namespace LfMergeBridgeTests
 					date=""2018-01-31T01:02:03Z""
 					guid=""449489a4-8e0e-4b98-a75d-b6263f4a4e6a"">
 				</message>"));
-			_inputFile = NotesTestHelper.CreateMongoDataFileById("\"Status\":\"open\",\"StatusGuid\":\"449489a4-8e0e-4b98-a75d-b6263f4a4e6a\",");
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", "449489a4-8e0e-4b98-a75d-b6263f4a4e6a");
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: {0}New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(0));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			AssertThatXmlIn.String(NotesTestHelper.GetAnnotationXml(
 @"		<message
 			author=""Language Forge""
@@ -279,18 +311,25 @@ namespace LfMergeBridgeTests
 <notes
 	version=""0"">
 </notes>");
-			_inputFile = NotesTestHelper.CreateMongoDataFileById("\"Status\":\"open\",", false);
+			var lfComments = NotesTestHelper.CreateLfCommentsListById("open", "", false);
 
 			string forClient = null;
 			var sutActionHandler = GetLanguageForgeWriteToChorusNotesActionHandler();
 
 			// Execute
-			sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient);
+			var options = GetOptions(projectDir, lfComments);
+			sutActionHandler.StartWorking(new NullProgress(), options, ref forClient);
 
 			// Verify
-			Assert.That(forClient, Is.EqualTo(string.Format(
-				"New comment ID->Guid mappings: 5a71f21c6efc676a612eb76f=1687b882-97c9-4ca0-9bc3-2a0511715400{0}" +
-				"New reply ID->Guid mappings: ", Environment.NewLine)));
+			var found = LfMergeBridge.LfMergeBridge.ExtraOutputData.TryGetValue(options, out var outputObject);
+			Assert.IsTrue(found, "No output comments from LfMergeBridge");
+			Assert.NotNull(outputObject);
+			var response = outputObject as WriteToChorusNotesResponse;
+			Assert.That(response, Is.Not.Null);
+			Assert.That(response.CommentIdsThatNeedGuids.Count, Is.EqualTo(1));
+			Assert.That(response.CommentIdsThatNeedGuids.Keys.ToList(), Is.EquivalentTo(new List<string> { "5a71f21c6efc676a612eb76f" } ));
+			Assert.That(response.CommentIdsThatNeedGuids["5a71f21c6efc676a612eb76f"], Is.EqualTo(new Guid("1687b882-97c9-4ca0-9bc3-2a0511715400")));
+			Assert.That(response.ReplyIdsThatNeedGuids.Count, Is.EqualTo(0));
 			// REVIEW: It's surprising that we ignore the DateCreated/Modified from LF
 			AssertThatXmlIn.String(NotesTestHelper.GetAnnotationXml(
 @"		<message
@@ -317,7 +356,7 @@ namespace LfMergeBridgeTests
 
 			// Execute/Verify
 			Assert.That(
-				() => sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir), ref forClient),
+				() => sutActionHandler.StartWorking(new NullProgress(), GetOptions(projectDir, new List<LfComment>()), ref forClient),
 				Throws.Nothing);
 		}
 

--- a/src/LfMergeBridgeTests/NotesTestHelper.cs
+++ b/src/LfMergeBridgeTests/NotesTestHelper.cs
@@ -1,6 +1,9 @@
-﻿// Copyright (c) 2018 SIL International
+// Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
 using System.IO;
+using LfMergeBridge.LfMergeModel;
 using SIL.IO;
 
 namespace LfMergeBridgeTests
@@ -28,33 +31,36 @@ namespace LfMergeBridgeTests
 				messagesXml, annotationGuid);
 		}
 
-		public static TempFile CreateMongoDataFileById(string statusFields, bool addAnnotationGuid = true)
+		public static List<LfComment> CreateLfCommentsListById(string status, string statusGuid, bool addAnnotationGuid = true)
 		{
-			return new TempFile(string.Format(@"[{{""Key"":""5a71f21c6efc676a612eb76f"",
-""Value"":{{""Id"":""5a71f21c6efc676a612eb76f"",{0}
-""AuthorInfo"":{{""CreatedByUserRef"":""5a2671036efc6737ab1f1f82"",""CreatedDate"":""2018-01-31T16:43:08.474Z"",""ModifiedByUserRef"":""5a2671036efc6737ab1f1f82"",""ModifiedDate"":""2018-01-31T16:43:08.474Z""}},
-""Regarding"":{{""TargetGuid"":""1e7a8774-da73-49de-83bf-a613c12bb281"",""Word"":""F"",""Meaning"":""F""}},
-""DateCreated"":""2018-01-31T16:43:08.474Z"",""DateModified"":""2018-01-31T16:43:08.474Z"",
-""Content"":""LF comment on F"",
-{1}
-""IsDeleted"":false,""EntryRef"":""5a3801ee511fd55d813e1f76"",""Score"":0}}}}]",
-				addAnnotationGuid ? "\"Guid\":\"e8a03b36-2c36-4647-b879-24dbcd5a9ac4\"," : "",
-				statusFields));
+			var date = new DateTime(2018, 1, 31, 16, 43, 8, 474, DateTimeKind.Utc);
+			var comment = new LfComment
+			{
+				DateCreated = date,
+				DateModified = date,
+				AuthorInfo = new LfAuthorInfo
+				{
+					CreatedByUserRef = new MongoDB.Bson.ObjectId("5a2671036efc6737ab1f1f82"),
+					CreatedDate = date,
+					ModifiedByUserRef = new MongoDB.Bson.ObjectId("5a2671036efc6737ab1f1f82"),
+					ModifiedDate = date,
+				},
+				Regarding = new LfCommentRegarding
+				{
+					TargetGuid = "1e7a8774-da73-49de-83bf-a613c12bb281",
+					Word = "F",
+					Meaning = "F",
+				},
+				Content = "LF comment on F",
+				Status = status,
+				IsDeleted = false,
+				EntryRef = new MongoDB.Bson.ObjectId("5a3801ee511fd55d813e1f76"),
+				Score = 0,
+			};
+			if (addAnnotationGuid) comment.Guid = new Guid("e8a03b36-2c36-4647-b879-24dbcd5a9ac4");
+			if (!string.IsNullOrEmpty(statusGuid)) comment.StatusGuid = new Guid(statusGuid);
+			return new List<LfComment> { comment };
 		}
-
-		public static TempFile CreateMongoDataFileAsList(string statusFields, bool addAnnotationGuid = true)
-		{
-			return new TempFile(string.Format(@"[{{""Id"":""5a71f21c6efc676a612eb76f"",{0}
-""AuthorInfo"":{{""CreatedByUserRef"":""5a2671036efc6737ab1f1f82"",""CreatedDate"":""2018-02-01T12:13:14Z"",""ModifiedByUserRef"":""5a2671036efc6737ab1f1f82"",""ModifiedDate"":""2018-02-01T12:13:14Z""}},
-""Regarding"":{{""TargetGuid"":""1e7a8774-da73-49de-83bf-a613c12bb281"",""Word"":""F"",""Meaning"":""F""}},
-""DateCreated"":""2018-02-01T12:13:14Z"",""DateModified"":""2018-02-01T12:13:14Z"",
-""Content"":""LF comment on F"",
-{1}
-""IsDeleted"":false,""EntryRef"":""5a3801ee511fd55d813e1f76"",""Score"":0}}]",
-				addAnnotationGuid ? "\"Guid\":\"e8a03b36-2c36-4647-b879-24dbcd5a9ac4\"," : "",
-				statusFields));
-		}
-
 	}
 }
 


### PR DESCRIPTION
New API (introduced in #401 and #402) for LfMergeBridge passes LfComment lists directly rather than serialized to JSON, so the tests need to do the same.

Fixes #415.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/416)
<!-- Reviewable:end -->
