### PR TITLE
Add forgotten SetupFixture necessary after the L10nSharp update

### DIFF
--- a/src/LibFLExBridge-ChorusPluginTests/SetupFixture.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/SetupFixture.cs
@@ -1,0 +1,15 @@
+using L10NSharp;
+using NUnit.Framework;
+
+namespace LibFLExBridgeChorusPluginTests
+{
+	[SetUpFixture]
+	public class SetupFixture
+	{
+		[OneTimeSetUp]
+		public void RunBeforeAnyTests()
+		{
+			LocalizationManager.StrictInitializationMode = false;
+		}
+	}
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/417)
<!-- Reviewable:end -->
