### PR TITLE
Fix LT-21970: S/R failure with reordering data entry fields

### DIFF
--- a/src/LibFLExBridge-ChorusPlugin/Handling/ConfigLayout/FieldWorksConfigurationLayoutValidator.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/ConfigLayout/FieldWorksConfigurationLayoutValidator.cs
@@ -29,8 +29,10 @@ namespace LibFLExBridgeChorusPlugin.Handling.ConfigLayout
 							return ValidateLayoutTypeElement(childElement);
 						case "layout":
 							return ValidateLayoutElement(childElement);
+						case "part":
+							return ValidatePartElement(childElement);
 						default:
-							return "Layout file contains unrecognized child element.";
+							return "Layout file contains unrecognized child element: " + childElement.Name.LocalName + ".";
 					}
 				}
 			}
@@ -108,7 +110,7 @@ namespace LibFLExBridgeChorusPlugin.Handling.ConfigLayout
 					case "generate":
 						return ValidateGenerateElement(childElement);
 					default:
-						return "Layout element contains unrecognized child element.";
+						return "Layout element contains unrecognized child element" + childElement.Name.LocalName + ".";
 				}
 			}
 			return null;
@@ -118,6 +120,14 @@ namespace LibFLExBridgeChorusPlugin.Handling.ConfigLayout
 		{
 			if (part.Attribute("ref") == null)
 				return "Required 'ref' attribute is missing.";
+			foreach (var childElement in part.Elements())
+			{
+				if (childElement.Name.LocalName == "indent")
+					foreach (var grandChildElement in childElement.Elements())
+					{
+						ValidatePartElement(grandChildElement);
+					}
+			}
 
 			return null;
 		}

--- a/src/LibFLExBridge-ChorusPlugin/Handling/ConfigLayout/FieldWorksConfigurationLayoutValidator.cs
+++ b/src/LibFLExBridge-ChorusPlugin/Handling/ConfigLayout/FieldWorksConfigurationLayoutValidator.cs
@@ -123,10 +123,12 @@ namespace LibFLExBridgeChorusPlugin.Handling.ConfigLayout
 			foreach (var childElement in part.Elements())
 			{
 				if (childElement.Name.LocalName == "indent")
+				{
 					foreach (var grandChildElement in childElement.Elements())
 					{
 						ValidatePartElement(grandChildElement);
 					}
+				}
 			}
 
 			return null;

--- a/src/LibFLExBridge-ChorusPluginTests/Handling/ConfigLayout/FieldWorksCustomLayoutTypeHandlerTests.cs
+++ b/src/LibFLExBridge-ChorusPluginTests/Handling/ConfigLayout/FieldWorksCustomLayoutTypeHandlerTests.cs
@@ -13,6 +13,7 @@ using LibChorus.TestUtilities;
 using NUnit.Framework;
 using SIL.IO;
 using SIL.Progress;
+using System.Text.RegularExpressions;
 
 namespace LibFLExBridgeChorusPluginTests.Handling.ConfigLayout
 {
@@ -107,6 +108,24 @@ namespace LibFLExBridgeChorusPluginTests.Handling.ConfigLayout
 
 			File.WriteAllText(_ourFile.Path, data);
 			Assert.IsNotNull(FileHandler.ValidateFile(_ourFile.Path, new NullProgress()));
+		}
+
+		[Test]
+		public void ShouldBeAbleToValidateFileWithPartAndIndent()
+		{
+			const string data =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+  <LayoutInventory>
+  <part ref=""HeavySummary"" param=""Summary"" collapsedLayout=""SummaryCollapsed"" expansion=""expanded"" menu=""mnuDataTree-Sense"" hotlinks=""mnuDataTree-Sense-Hotlinks"" notifyVirtual=""LexSenseOutline"">
+	<indent>
+		<part ref=""Exemplar"" visibility=""ifdata"" />
+		<part ref=""ReversalEntries"" visibility=""ifdata"" />
+	</indent>
+  </part>
+</LayoutInventory>";
+
+			File.WriteAllText(_ourFile.Path, data);
+			Assert.IsNull(FileHandler.ValidateFile(_ourFile.Path, new NullProgress()));
 		}
 
 		[Test]
@@ -357,5 +376,45 @@ namespace LibFLExBridgeChorusPluginTests.Handling.ConfigLayout
 			Assert.IsFalse(results.Contains("combinedkey"));
 
 		}
+
+		[Test]
+		public void SampleMergeWithPartAndIndent()
+		{
+			const string commonAncestor =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+  <LayoutInventory>
+  <part ref=""HeavySummary"" param=""Summary"" collapsedLayout=""SummaryCollapsed"" expansion=""expanded"" menu=""mnuDataTree-Sense"" hotlinks=""mnuDataTree-Sense-Hotlinks"" notifyVirtual=""LexSenseOutline"">
+	<indent>
+		<part ref=""Exemplar"" visibility=""ifdata"" />
+		<part ref=""ReversalEntries"" visibility=""ifdata"" />
+	</indent>
+  </part>
+</LayoutInventory>";
+			const string ourContent =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+  <LayoutInventory>
+  <part ref=""HeavySummary"" param=""Summary"" collapsedLayout=""SummaryCollapsed"" expansion=""expanded"" menu=""mnuDataTree-Sense"" hotlinks=""mnuDataTree-Sense-Hotlinks"" notifyVirtual=""LexSenseOutline"">
+	<indent>
+		<part ref=""ReversalEntries"" visibility=""ifdata"" />
+		<part ref=""Exemplar"" visibility=""ifdata"" />
+	</indent>
+  </part>
+</LayoutInventory>";
+
+			const string theirContent = commonAncestor;
+
+			var results = FieldWorksTestServices.DoMerge(
+				FileHandler,
+				_ourFile, ourContent,
+				_commonFile, commonAncestor,
+				_theirFile, theirContent,
+				null, null,
+				0, new List<Type>(),
+				1, new List<Type> { typeof(XmlChangedRecordReport) });
+			string normalizedResults = Regex.Replace(results, @"\s", "");
+			string normalizedOurContent = Regex.Replace(ourContent, @"\s", "");
+			Assert.AreEqual(normalizedResults, normalizedOurContent);
+		}
+
 	}
 }


### PR DESCRIPTION
It couldn't validate:
<?xml version=""1.0"" encoding=""utf-8""?>
  <LayoutInventory>
  <part ref=""HeavySummary"" param=""Summary"" collapsedLayout=""SummaryCollapsed"" expansion=""expanded"" menu=""mnuDataTree-Sense"" hotlinks=""mnuDataTree-Sense-Hotlinks"" notifyVirtual=""LexSenseOutline"">
	<indent>
		<part ref=""Exemplar"" visibility=""ifdata"" />
		<part ref=""ReversalEntries"" visibility=""ifdata"" />
	</indent>
  </part>
</LayoutInventory>
because of the lack of <layout></layout> around the part.
I changed the validator and added a unit test for both layout and merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/flexbridge/422)
<!-- Reviewable:end -->
